### PR TITLE
Add missing default configuration for versionchecker.enabled

### DIFF
--- a/src/bits/config.cc
+++ b/src/bits/config.cc
@@ -57,7 +57,9 @@ char const* default_config =
     "[updater]\n"
     "  autocheck = true\n"
     "  check_interval = 604800\n"
-    "  last_update = 0\n";
+    "  last_update = 0\n"
+    "[versionchecker]\n"
+    "  enabled = false\n";
 
 /* The initial configuration is loaded once if the configuration
  * file is created for the first time. Thus it initializes the


### PR DESCRIPTION
It crashes for me without this:
"what: Path to key does not exist: versionchecker.enabled"
