### PR TITLE
Remove skill clones

### DIFF
--- a/src/api/apicharsheet.cc
+++ b/src/api/apicharsheet.cc
@@ -140,8 +140,6 @@ ApiCharSheet::parse_result_tag (xmlNodePtr node)
     this->set_string_if_node_text(node, "gender", this->gender);
     this->set_string_if_node_text(node, "corporationName", this->corp);
     this->set_string_if_node_text(node, "balance", this->balance);
-    this->set_string_if_node_text(node, "cloneName", this->clone_name);
-    this->set_uint_if_node_text(node, "cloneSkillPoints", this->clone_sp);
 
     if (!xmlStrcmp(node->name, (xmlChar const*)"attributes"))
       this->parse_attribute_tag(node->children);

--- a/src/api/apicharsheet.h
+++ b/src/api/apicharsheet.h
@@ -110,8 +110,6 @@ class ApiCharSheet : public ApiBase
     std::string gender;
     std::string corp;
     std::string balance;
-    std::string clone_name;
-    unsigned int clone_sp;
 
     /* Attribute values for the character. */
     ApiCharAttribs base;

--- a/src/bits/character.h
+++ b/src/bits/character.h
@@ -22,7 +22,6 @@
 #include "api/apiskillqueue.h"
 
 /* TODO
- * Emit signal if clone runs out of SP?
  * Move caching to this class? This enables to read API errors
  */
 

--- a/src/gui/gtkcharpage.cc
+++ b/src/gui/gtkcharpage.cc
@@ -51,7 +51,6 @@ GtkCharPage::GtkCharPage (CharacterPtr character)
   this->corp_label.set_alignment(Gtk::ALIGN_LEFT);
   this->balance_label.set_alignment(Gtk::ALIGN_LEFT);
   this->skill_points_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->clone_warning_label.set_alignment(Gtk::ALIGN_LEFT);
   this->known_skills_label.set_alignment(Gtk::ALIGN_LEFT);
   this->attr_cha_label.set_alignment(Gtk::ALIGN_LEFT);
   this->attr_int_label.set_alignment(Gtk::ALIGN_LEFT);
@@ -142,10 +141,9 @@ GtkCharPage::GtkCharPage (CharacterPtr character)
   Gtk::HBox* char_buts_hbox = MK_HBOX;
   char_buts_hbox->pack_end(*char_buts_vbox, false, false, 0);
 
-  /* Character SP and clone warning box. */
+  /* Character SP */
   Gtk::HBox* char_skillpoints_box = MK_HBOX;
   char_skillpoints_box->pack_start(this->skill_points_label, false, false, 0);
-  char_skillpoints_box->pack_start(this->clone_warning_label, false, false, 0);
 
   info_table->attach(this->char_image, 0, 1, 0, 5, Gtk::SHRINK, Gtk::SHRINK);
   info_table->attach(this->char_name_label, 1, 2, 0, 1, Gtk::FILL, Gtk::FILL);
@@ -363,23 +361,6 @@ GtkCharPage::update_charsheet_details (void)
         skills_at_tt += "\n";
     }
 
-    /* Build clone information (tooltip). */
-    Glib::ustring clone_tt;
-    clone_tt = "<u><b>Character clone information</b></u>\nName: ";
-    clone_tt += cs->clone_name + "\nKeeps: ";
-    clone_tt += Helpers::get_dotted_str_from_uint(cs->clone_sp);
-    clone_tt += " SP";
-
-    if (this->character->char_base_sp > cs->clone_sp)
-    {
-      clone_tt += "\n\n<b>Warning:</b> Your clone is outdated!";
-      this->clone_warning_label.set_markup("<b>(outdated)</b>");
-    }
-    else
-    {
-      this->clone_warning_label.set_text("");
-    }
-
     /* Build detailed attribute information (tooltip). */
     Glib::ustring attr_cha_tt;
     attr_cha_tt = "<u><b>Attribute: Charisma</b></u>\nBase: ";
@@ -413,8 +394,6 @@ GtkCharPage::update_charsheet_details (void)
 
     /* Update some character sheet related skills. */
     this->known_skills_label.set_tooltip_markup(skills_at_tt);
-    this->skill_points_label.set_tooltip_markup(clone_tt);
-    this->clone_warning_label.set_tooltip_markup(clone_tt);
     this->attr_cha_label.set_tooltip_markup(attr_cha_tt);
     this->attr_int_label.set_tooltip_markup(attr_int_tt);
     this->attr_per_label.set_tooltip_markup(attr_per_tt);

--- a/src/gui/gtkcharpage.h
+++ b/src/gui/gtkcharpage.h
@@ -70,7 +70,6 @@ class GtkCharPage : public Gtk::VBox
     Gtk::Label corp_label;
     Gtk::Label balance_label;
     Gtk::Label skill_points_label;
-    Gtk::Label clone_warning_label;
     Gtk::Label known_skills_label;
     Gtk::Label attr_cha_label;
     Gtk::Label attr_int_label;


### PR DESCRIPTION
Remove all references to skill clones - including the "clone out of date" warning.

Closes #29.