### PR TITLE
Change socket classes to be ip version agnostic.

### DIFF
--- a/src/net/http.cc
+++ b/src/net/http.cc
@@ -165,8 +165,11 @@ Http::initialize_connection (Net::TCPSocket* sock)
 
   if (this->proxy.empty())
   {
-    in_addr_t host_addr = Net::DNSLookup::get_hostname(this->host);
-    sock->connect(host_addr, this->port);
+    /*
+     * TODO: Why was this using it's own dns lookup?
+     * in_addr_t host_addr = Net::DNSLookup::get_hostname(this->host);
+     */
+    sock->connect(this->host, this->port);
   }
   else
   {

--- a/src/net/netdnslookup.cc
+++ b/src/net/netdnslookup.cc
@@ -1,7 +1,7 @@
 #ifndef WIN32
 # include <sys/types.h> // for netdb.h
 # include <sys/socket.h> // for netdb.h
-# include <netinet/in.h> // sockaddr_in
+# include <netinet/in.h> // sockaddr_storage
 # include <netdb.h> // ::getaddrinfo, ::freeaddrinfo
 #else
 # include <ws2tcpip.h>
@@ -15,7 +15,7 @@
 
 NET_NAMESPACE_BEGIN
 
-in_addr_t
+struct addrinfo*
 DNSLookup::get_hostname (char const* dnsname)
 {
   struct addrinfo hints;
@@ -31,15 +31,12 @@ DNSLookup::get_hostname (char const* dnsname)
         + std::string(::gai_strerror(retval)));
   }
 
-  in_addr_t result = ((struct sockaddr_in*)res->ai_addr)->sin_addr.s_addr;
-  ::freeaddrinfo(res);
-
-  return result;
+  return res;
 }
 
 /* ---------------------------------------------------------------- */
 
-in_addr_t
+struct addrinfo*
 DNSLookup::get_hostname (std::string const& dnsname)
 {
   return DNSLookup::get_hostname(dnsname.c_str());

--- a/src/net/netdnslookup.h
+++ b/src/net/netdnslookup.h
@@ -20,8 +20,8 @@ NET_NAMESPACE_BEGIN
 class DNSLookup
 {
   public:
-    static in_addr_t get_hostname (char const* dnsname);
-    static in_addr_t get_hostname (std::string const& dnsname);
+    static struct addrinfo* get_hostname (char const* dnsname);
+    static struct addrinfo* get_hostname (std::string const& dnsname);
 };
 
 NET_NAMESPACE_END

--- a/src/net/netssltcpsocket.cc
+++ b/src/net/netssltcpsocket.cc
@@ -55,7 +55,6 @@ SSLTCPSocket::ssl_handshake (void)
         this->close();
         throw Exception("SSL error connecting.");
     }
-
     this->check_cert();
 }
 

--- a/src/net/nettcpsocket.h
+++ b/src/net/nettcpsocket.h
@@ -29,8 +29,8 @@ NET_NAMESPACE_BEGIN
 class TCPSocket : public Socket
 {
   protected:
-    struct sockaddr_in remote;
-    struct sockaddr_in local;
+    struct sockaddr_storage remote;
+    struct sockaddr_storage local;
     std::size_t timeout;
 
   public:
@@ -73,7 +73,7 @@ class TCPSocket : public Socket
     /**
      * Same as the function above but it uses another host format.
      */
-    virtual void connect (in_addr_t host, int port);
+    void connect (struct addrinfo *addr);
 
     /**
      * The `set_connect_timeout' function allows to define a timeout in
@@ -81,42 +81,6 @@ class TCPSocket : public Socket
      * fail if no connection has been established if the timeout expires.
      */
     void set_connect_timeout (std::size_t timeout_ms);
-
-    /**
-     * The `get_local_port' function returns the remote port.
-     */
-    int get_local_port (void) const;
-
-    /**
-     * The `get_remote_port' function returns the remote port.
-     */
-    int get_remote_port (void) const;
-
-    /**
-     * The `get_local_address' function returns the local address in the
-     * standard numbers-and-dots notation.
-     */
-    std::string get_local_address (void) const;
-
-    /**
-     * The `get_remote_address' function returns the remote address in the
-     * standard numbers-and-dots notation.
-     */
-    std::string get_remote_address (void) const;
-
-    /*
-     * The `get_full_local' function returns the local address in the
-     * standard numbers-and-dots notation, followed by a colon (":") and
-     * the local port.
-     */
-    std::string get_full_local (void) const;
-
-    /*
-     * The `get_full_remote' function returns the remote address in the
-     * standard numbers-and-dots notation, followed by a colon (":") and
-     * the remote port.
-     */
-    std::string get_full_remote (void) const;
 };
 
 NET_NAMESPACE_END


### PR DESCRIPTION
This adds ipv6 support.  Also removed some unused methods.

I've only tried to compile and run this on linux and it seems to work fine with both ipv4 and ipv6. 
If gtkevemon is supposed to work on mac os x and windows it would be great if someone could test this there.