### PR TITLE
Fixed the TLS handling to default to TLS 1.x instead of using SSLv3

### DIFF
--- a/src/net/networking.cc
+++ b/src/net/networking.cc
@@ -90,7 +90,8 @@ ssl_context (void)
     //BIO* bio_err = BIO_new_fp(stderr, BIO_NOCLOSE);
 
     /* Create SSL Context. */
-    SSL_CTX* ctx = SSL_CTX_new(SSLv3_client_method());
+    SSL_CTX* ctx = SSL_CTX_new(SSLv23_client_method());
+    SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv3);
 
     /* Load CAs we trust. */
 


### PR DESCRIPTION
exclusively, which breaks the API due to CCP disabling SSLv3 on the
serverside b/c of the POODLE vuln.