### PR TITLE
add a (hideable) column with primary/secondary attribute to skill queue window.

### DIFF
--- a/src/gui/gtkskillqueue.cc
+++ b/src/gui/gtkskillqueue.cc
@@ -21,7 +21,8 @@ GtkSkillQueueViewCols::GtkSkillQueueViewCols (Gtk::TreeView* view,
     start_time("Start time", cols->start_time),
     end_time("Finish time", cols->end_time),
     duration("Duration", cols->duration),
-    training("Training", cols->training)
+    training("Training", cols->training),
+    attribs("Attribs", cols->attribs)
 {
   this->skill_name.set_title("Skill name");
   this->skill_name.pack_start(cols->skill_icon, false);
@@ -38,6 +39,7 @@ GtkSkillQueueViewCols::GtkSkillQueueViewCols (Gtk::TreeView* view,
   this->append_column(&this->end_time, GtkColumnOptions(true, false, true));
   this->append_column(&this->duration, GtkColumnOptions(true, false, true));
   this->append_column(&this->training, GtkColumnOptions(true, false, true));
+  this->append_column(&this->attribs, GtkColumnOptions(true, false, true));
 
   this->position.get_first_cell_renderer()->set_property("xalign", 1.0f);
   this->skill_name.set_expand(true);
@@ -170,6 +172,14 @@ GtkSkillQueue::on_apidata_available (void)
         = EveTime::get_string_for_timediff(duration, true);
     row[this->queue_cols.training]
         = EveTime::get_string_for_timediff(training, true);
+
+    Glib::ustring attribs;
+    attribs += ApiSkillTree::get_attrib_short_name(skill->primary);
+    attribs += " / ";
+    attribs += ApiSkillTree::get_attrib_short_name(skill->secondary);
+    row[this->queue_cols.attribs]
+      = attribs;
+
     row[this->queue_cols.skill_id] = item.skill_id;
   }
 }

--- a/src/gui/gtkskillqueue.h
+++ b/src/gui/gtkskillqueue.h
@@ -33,6 +33,7 @@ class GtkSkillQueueColumns : public Gtk::TreeModel::ColumnRecord
     Gtk::TreeModelColumn<Glib::ustring> end_time;
     Gtk::TreeModelColumn<Glib::ustring> duration;
     Gtk::TreeModelColumn<Glib::ustring> training;
+    Gtk::TreeModelColumn<Glib::ustring> attribs;
     Gtk::TreeModelColumn<int> skill_id;
 
     GtkSkillQueueColumns (void);
@@ -51,6 +52,7 @@ class GtkSkillQueueViewCols : public GtkColumnsBase
     Gtk::TreeView::Column end_time;
     Gtk::TreeView::Column duration;
     Gtk::TreeView::Column training;
+    Gtk::TreeView::Column attribs;
     Gtk::TreeView::Column skill_id;
 
     GtkSkillQueueViewCols (Gtk::TreeView* view, GtkSkillQueueColumns* cols);
@@ -99,6 +101,7 @@ GtkSkillQueueColumns::GtkSkillQueueColumns (void)
   this->add(this->end_time);
   this->add(this->duration);
   this->add(this->training);
+  this->add(this->attribs);
   this->add(this->skill_id);
 }
 


### PR DESCRIPTION
![attribs](https://cloud.githubusercontent.com/assets/215510/7812284/407872a2-03b1-11e5-897f-91cc64080951.jpg)
