### PR TITLE
Makefile and icon/Makefile edited to support user-defined prefix.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-PREFIX = $(DESTDIR)/usr/local
-BINDIR = $(PREFIX)/bin
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
 
 all:
 	$(MAKE) -C src
@@ -11,9 +11,9 @@ clean:
 	$(MAKE) -C src clean
 
 install:
-	install -Dm 755 src/gtkevemon $(BINDIR)/gtkevemon
+	install -Dm 755 src/gtkevemon $(DESTDIR)$(BINDIR)/gtkevemon
 	$(MAKE) -C icon
 
 uninstall:
-	${RM} $(BINDIR)/gtkevemon
+	${RM} $(DESTDIR)$(BINDIR)/gtkevemon
 	$(MAKE) -C icon uninstall

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX = /usr/local
+PREFIX = $(DESTDIR)/usr/local
 BINDIR = $(PREFIX)/bin
 
 all:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-INSTALL_BIN = /usr/local/bin
+PREFIX = /usr/local
+BINDIR = $(PREFIX)/bin
 
 all:
 	$(MAKE) -C src
@@ -10,9 +11,9 @@ clean:
 	$(MAKE) -C src clean
 
 install:
-	install -Dm 755 src/gtkevemon ${INSTALL_BIN}/gtkevemon
+	install -Dm 755 src/gtkevemon $(BINDIR)/gtkevemon
 	$(MAKE) -C icon
 
 uninstall:
-	${RM} ${INSTALL_BIN}/gtkevemon
+	${RM} $(BINDIR)/gtkevemon
 	$(MAKE) -C icon uninstall

--- a/README
+++ b/README
@@ -55,8 +55,12 @@ and the default locations for the icon and .desktop file are
 respectively.
 
 If you want to change the default location, use the PREFIX environment
-variable, or edit the Makefile directly. eg, set PREFIX to "/usr" to
-install in "/usr/bin", "/usr/share/pixmaps", etc.
+variable, or edit the Makefile directly. If unset, PREFIX Will default
+to "/usr/local".
+
+The Makefile also supports the DESTDIR variable. DESTDIR will be
+prepended to PREFIX, preserving the directory structure of the
+installation while installing to a non-standard location.
 
 Configuration files as well as data files (SkillTree.xml and
 CertificateTree.xml) are placed in "~/.gtkevemon" whether you

--- a/README
+++ b/README
@@ -49,12 +49,18 @@ To install GtkEveMon execute the following command (as super user):
 
     # make install
 
-The files will be installed to "/usr/local/bin". If you want to change
-that, edit the Makefile.
+The default location for the gtkevemon executable is "/usr/local/bin",
+and the default locations for the icon and .desktop file are
+"/usr/local/share/pixmaps" and "/usr/local/share/applications",
+respectively.
+
+If you want to change the default location, use the PREFIX environment
+variable, or edit the Makefile directly. eg, set PREFIX to "/usr" to
+install in "/usr/bin", "/usr/share/pixmaps", etc.
 
 Configuration files as well as data files (SkillTree.xml and
 CertificateTree.xml) are placed in "~/.gtkevemon" whether you
-install GtkEveMon or not.
+install GtkEveMon or not. This is not changeable at runtime.
 
 
 OPTION: UNINSTALLING

--- a/icon/Makefile
+++ b/icon/Makefile
@@ -1,12 +1,12 @@
-PREFIX = $(DESTDIR)/usr/local
-DATAROOTDIR = $(PREFIX)/share
-PIXMAPDIR = $(DATAROOTDIR)/pixmaps
-DESKTOPDIR = $(DATAROOTDIR)/applications
+PREFIX ?= /usr/local
+DATAROOTDIR ?= $(PREFIX)/share
+PIXMAPDIR ?= $(DATAROOTDIR)/pixmaps
+DESKTOPDIR ?= $(DATAROOTDIR)/applications
 
 install:
-	install -Dm 644 gtkevemon.svg $(PIXMAPDIR)/gtkevemon.svg
-	install -Dm 644 gtkevemon.desktop $(DESKTOPDIR)/gtkevemon.desktop
+	install -Dm 644 gtkevemon.svg $(DESTDIR)$(PIXMAPDIR)/gtkevemon.svg
+	install -Dm 644 gtkevemon.desktop $(DESTDIR)$(DESKTOPDIR)/gtkevemon.desktop
 
 uninstall:
-	rm $(PIXMAPDIR)/gtkevemon.svg
-	rm $(DESKTOPDIR)/gtkevemon.desktop
+	rm $(DESTDIR)$(PIXMAPDIR)/gtkevemon.svg
+	rm $(DESTDIR)$(DESKTOPDIR)/gtkevemon.desktop

--- a/icon/Makefile
+++ b/icon/Makefile
@@ -1,3 +1,4 @@
+PREFIX = $(DESTDIR)/usr/local
 DATAROOTDIR = $(PREFIX)/share
 PIXMAPDIR = $(DATAROOTDIR)/pixmaps
 DESKTOPDIR = $(DATAROOTDIR)/applications

--- a/icon/Makefile
+++ b/icon/Makefile
@@ -1,10 +1,11 @@
-INSTALL_DIR_ICON = /usr/share/pixmaps/
-INSTALL_DIR_DESK = /usr/share/applications/
+DATAROOTDIR = $(PREFIX)/share
+PIXMAPDIR = $(DATAROOTDIR)/pixmaps
+DESKTOPDIR = $(DATAROOTDIR)/applications
 
 install:
-	install -Dm 644 gtkevemon.svg ${INSTALL_DIR_ICON}/gtkevemon.svg
-	install -Dm 644 gtkevemon.desktop ${INSTALL_DIR_DESK}/gtkevemon.desktop
+	install -Dm 644 gtkevemon.svg $(PIXMAPDIR)/gtkevemon.svg
+	install -Dm 644 gtkevemon.desktop $(DESKTOPDIR)/gtkevemon.desktop
 
 uninstall:
-	rm ${INSTALL_DIR_ICON}/gtkevemon.svg
-	rm ${INSTALL_DIR_DESK}/gtkevemon.desktop
+	rm $(PIXMAPDIR)/gtkevemon.svg
+	rm $(DESKTOPDIR)/gtkevemon.desktop


### PR DESCRIPTION
Makefiles now support a user-defined installation prefix. To use, run make as normal, and then:
make install PREFIX=/wherever/you/want