### PR TITLE
gtkmm3 port

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,7 @@ The required libraries to build GtkEveMon (which can be installed
 using your distribution's package management) are:
 
 	libxml++ (with headers)
-	libgtkmm (with headers, at least version 2.4)
+	libgtkmm (with headers, at least version 3.0)
 	libcurl (with headers, compiled with encryption support)
 
 The source does not come with a configure script. Just execute:
@@ -37,7 +37,7 @@ If you don't want to install GtkEveMon, just execute GtkEveMon with:
 
     $ ./src/gtkevemon
 
-Once you install GtkEveMon (read below), type "gtkevemon" anywhere 
+Once you install GtkEveMon (read below), type "gtkevemon" anywhere
 in your system or make a shortcut in your window manager.
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,10 +16,10 @@ ifdef DEBUG
 endif
 
 GCC_INCL = -I.
-GTK_FLAGS = $(shell pkg-config --cflags gtkmm-2.4)
+GTK_FLAGS = $(shell pkg-config --cflags gtkmm-3.0)
 XML_FLAGS = $(shell pkg-config --cflags libxml-2.0)
 
-GTK_LIBS = $(shell pkg-config --libs gtkmm-2.4)
+GTK_LIBS = $(shell pkg-config --libs gtkmm-3.0)
 XML_LIBS = $(shell pkg-config --libs libxml-2.0)
 PTH_LIBS = -lpthread
 ZLIB_LIBS = -lz

--- a/src/gui/gtkcharpage.cc
+++ b/src/gui/gtkcharpage.cc
@@ -1,17 +1,17 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <iostream>
 #include <sstream>
-#include <gtkmm/main.h>
-#include <gtkmm/messagedialog.h>
-#include <gtkmm/button.h>
-#include <gtkmm/label.h>
-#include <gtkmm/separator.h>
-#include <gtkmm/table.h>
-#include <gtkmm/box.h>
-#include <gtkmm/treeview.h>
-#include <gtkmm/image.h>
-#include <gtkmm/stock.h>
-#include <gtkmm/scrolledwindow.h>
-#include <gtkmm/alignment.h>
+
+#include <gtkmm.h>
 
 #include "util/helpers.h"
 #include "util/exception.h"
@@ -30,42 +30,40 @@
 #include "gtkcharpage.h"
 
 GtkCharPage::GtkCharPage (CharacterPtr character)
-  : Gtk::VBox(false, 5),
+  : Gtk::Box(Gtk::ORIENTATION_VERTICAL, 5),
     character(character),
     info_display(INFO_STYLE_TOP_HSEP)
 {
   /* Setup GUI. */
   this->char_image.set_enable_clicks();
 
-  this->refresh_but.set_image(*Gtk::manage(new Gtk::Image
-      (Gtk::Stock::REFRESH, Gtk::ICON_SIZE_MENU)));
+  this->refresh_but.set_image_from_icon_name("view-refresh", Gtk::ICON_SIZE_MENU);
   this->refresh_but.set_relief(Gtk::RELIEF_NONE);
   this->refresh_but.set_focus_on_click(false);
 
-  this->info_but.set_image(*Gtk::manage(new Gtk::Image
-      (Gtk::Stock::INFO, Gtk::ICON_SIZE_MENU)));
+  this->refresh_but.set_image_from_icon_name("dialog-information", Gtk::ICON_SIZE_MENU);
   this->info_but.set_relief(Gtk::RELIEF_NONE);
 
-  this->char_name_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->char_info_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->corp_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->balance_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->skill_points_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->known_skills_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->attr_cha_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->attr_int_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->attr_per_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->attr_mem_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->attr_wil_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->training_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->remaining_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->finish_eve_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->finish_local_label.set_alignment(Gtk::ALIGN_LEFT);
-  this->spph_label.set_alignment(Gtk::ALIGN_RIGHT);
-  this->live_sp_label.set_alignment(Gtk::ALIGN_RIGHT);
+  this->char_name_label.set_halign(Gtk::ALIGN_START);
+  this->char_info_label.set_halign(Gtk::ALIGN_START);
+  this->corp_label.set_halign(Gtk::ALIGN_START);
+  this->balance_label.set_halign(Gtk::ALIGN_START);
+  this->skill_points_label.set_halign(Gtk::ALIGN_START);
+  this->known_skills_label.set_halign(Gtk::ALIGN_START);
+  this->attr_cha_label.set_halign(Gtk::ALIGN_START);
+  this->attr_int_label.set_halign(Gtk::ALIGN_START);
+  this->attr_per_label.set_halign(Gtk::ALIGN_START);
+  this->attr_mem_label.set_halign(Gtk::ALIGN_START);
+  this->attr_wil_label.set_halign(Gtk::ALIGN_START);
+  this->training_label.set_halign(Gtk::ALIGN_START);
+  this->remaining_label.set_halign(Gtk::ALIGN_START);
+  this->finish_eve_label.set_halign(Gtk::ALIGN_START);
+  this->finish_local_label.set_halign(Gtk::ALIGN_START);
+  this->spph_label.set_halign(Gtk::ALIGN_END);
+  this->live_sp_label.set_halign(Gtk::ALIGN_END);
 
-  this->charsheet_info_label.set_alignment(Gtk::ALIGN_RIGHT);
-  this->skillqueue_info_label.set_alignment(Gtk::ALIGN_RIGHT);
+  this->charsheet_info_label.set_halign(Gtk::ALIGN_END);
+  this->skillqueue_info_label.set_halign(Gtk::ALIGN_END);
 
   /* Setup skill list. */
   Gtk::TreeViewColumn* name_column = Gtk::manage(new Gtk::TreeViewColumn);
@@ -93,9 +91,9 @@ GtkCharPage::GtkCharPage (CharacterPtr character)
   this->skill_view.append_column("Pri.", this->skill_cols.primary);
   this->skill_view.append_column("Sec.", this->skill_cols.secondary);
   this->skill_view.get_column(0)->set_expand(true);
-  this->skill_view.get_column(2)->get_first_cell_renderer()
+  this->skill_view.get_column(2)->get_first_cell()
       ->set_property("xalign", 1.0f);
-  this->skill_view.get_column(3)->get_first_cell_renderer()
+  this->skill_view.get_column(3)->get_first_cell()
       ->set_property("xalign", 1.0f);
 
   //this->skill_view.set_grid_lines(Gtk::TREE_VIEW_GRID_LINES_BOTH);
@@ -118,31 +116,30 @@ GtkCharPage::GtkCharPage (CharacterPtr character)
   Gtk::Label* attr_perception_desc = MK_LABEL("Perception:");
   Gtk::Label* attr_memory_desc = MK_LABEL("Memory:");
   Gtk::Label* attr_willpower_desc = MK_LABEL("Willpower:");
-  corp_desc->set_alignment(Gtk::ALIGN_LEFT);
-  isk_desc->set_alignment(Gtk::ALIGN_LEFT);
-  skillpoints_desc->set_alignment(Gtk::ALIGN_LEFT);
-  knownskills_desc->set_alignment(Gtk::ALIGN_LEFT);
-  attr_charisma_desc->set_alignment(Gtk::ALIGN_LEFT);
-  attr_intelligence_desc->set_alignment(Gtk::ALIGN_LEFT);
-  attr_perception_desc->set_alignment(Gtk::ALIGN_LEFT);
-  attr_memory_desc->set_alignment(Gtk::ALIGN_LEFT);
-  attr_willpower_desc->set_alignment(Gtk::ALIGN_LEFT);
+  corp_desc->set_halign(Gtk::ALIGN_START);
+  isk_desc->set_halign(Gtk::ALIGN_START);
+  skillpoints_desc->set_halign(Gtk::ALIGN_START);
+  knownskills_desc->set_halign(Gtk::ALIGN_START);
+  attr_charisma_desc->set_halign(Gtk::ALIGN_START);
+  attr_intelligence_desc->set_halign(Gtk::ALIGN_START);
+  attr_perception_desc->set_halign(Gtk::ALIGN_START);
+  attr_memory_desc->set_halign(Gtk::ALIGN_START);
+  attr_willpower_desc->set_halign(Gtk::ALIGN_START);
 
   Gtk::Button* close_but = MK_BUT0;
   close_but->set_relief(Gtk::RELIEF_NONE);
-  close_but->set_image(*Gtk::manage(new Gtk::Image
-      (Gtk::Stock::CLOSE, Gtk::ICON_SIZE_MENU)));
+  close_but->set_image_from_icon_name("window-close", Gtk::ICON_SIZE_MENU);
 
-  Gtk::VBox* char_buts_vbox = MK_VBOX0;
+  Gtk::Box* char_buts_vbox = MK_VBOX(0);
   char_buts_vbox->pack_start(*close_but, false, false, 0);
   //char_buts_vbox->pack_start(*MK_HSEP, true, true, 0);
   char_buts_vbox->pack_end(this->refresh_but, false, false, 0);
   char_buts_vbox->pack_end(this->info_but, false, false, 0);
-  Gtk::HBox* char_buts_hbox = MK_HBOX;
+  Gtk::Box* char_buts_hbox = MK_HBOX(5);
   char_buts_hbox->pack_end(*char_buts_vbox, false, false, 0);
 
   /* Character SP */
-  Gtk::HBox* char_skillpoints_box = MK_HBOX;
+  Gtk::Box* char_skillpoints_box = MK_HBOX(5);
   char_skillpoints_box->pack_start(this->skill_points_label, false, false, 0);
 
   info_table->attach(this->char_image, 0, 1, 0, 5, Gtk::SHRINK, Gtk::SHRINK);
@@ -177,17 +174,17 @@ GtkCharPage::GtkCharPage (CharacterPtr character)
   Gtk::Label* finish_eve_desc = MK_LABEL("Finish (EVE time):");
   Gtk::Label* finish_local_desc = MK_LABEL("Finish (local time):");
   train_desc->set_use_markup(true);
-  train_desc->set_alignment(Gtk::ALIGN_LEFT);
-  remain_desc->set_alignment(Gtk::ALIGN_LEFT);
-  finish_eve_desc->set_alignment(Gtk::ALIGN_LEFT);
-  finish_local_desc->set_alignment(Gtk::ALIGN_LEFT);
+  train_desc->set_halign(Gtk::ALIGN_START);
+  remain_desc->set_halign(Gtk::ALIGN_START);
+  finish_eve_desc->set_halign(Gtk::ALIGN_START);
+  finish_local_desc->set_halign(Gtk::ALIGN_START);
 
   Gtk::Label* charsheet_info_desc = MK_LABEL("Character sheet:");
   Gtk::Label* trainsheet_info_desc = MK_LABEL("Skill queue:");
-  Gtk::HBox* charsheet_info_hbox = MK_HBOX;
+  Gtk::Box* charsheet_info_hbox = MK_HBOX(5);
   charsheet_info_hbox->pack_end(this->charsheet_info_label, false, false, 0);
   charsheet_info_hbox->pack_end(*charsheet_info_desc, false, false, 0);
-  Gtk::HBox* trainsheet_info_hbox = MK_HBOX;
+  Gtk::Box* trainsheet_info_hbox = MK_HBOX(5);
   trainsheet_info_hbox->pack_end(this->skillqueue_info_label, false, false, 0);
   trainsheet_info_hbox->pack_end(*trainsheet_info_desc, false, false, 0);
 
@@ -789,7 +786,7 @@ GtkCharPage::create_tray_notify (void)
   this->tray_notify->signal_activate().connect(sigc::mem_fun
      (*this, &GtkCharPage::remove_tray_notify));
   //this->tray_notify->set_blinking(true);
-  this->tray_notify->set_tooltip(this->character->get_char_name() + " has "
+  this->tray_notify->set_tooltip_text(this->character->get_char_name() + " has "
       "completed " + this->training_label.get_text() + "!");
 }
 

--- a/src/gui/gtkcharpage.h
+++ b/src/gui/gtkcharpage.h
@@ -1,29 +1,20 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GTK_CHAR_PAGE_HEADER
 #define GTK_CHAR_PAGE_HEADER
 
 #include <string>
-#include <gdkmm/pixbuf.h>
-#include <gtkmm/box.h>
-#include <gtkmm/label.h>
-#include <gtkmm/button.h>
-#include <gtkmm/treeview.h>
-#include <gtkmm/image.h>
-#include <gtkmm/frame.h>
-#include <gtkmm/treestore.h>
-#include <gtkmm/statusicon.h>
-#include <gtkmm/tooltip.h>
+
+#include <gdkmm.h>
+#include <gtkmm.h>
 
 #include "bits/character.h"
 
@@ -57,7 +48,7 @@ class GtkCharSkillsCols : public Gtk::TreeModel::ColumnRecord
 
 /* ---------------------------------------------------------------- */
 
-class GtkCharPage : public Gtk::VBox
+class GtkCharPage : public Gtk::Box
 {
   private:
     /* Character to be monitored. */

--- a/src/gui/gtkcolumnsbase.cc
+++ b/src/gui/gtkcolumnsbase.cc
@@ -1,8 +1,16 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <iostream>
-#include <gtkmm/image.h>
-#include <gtkmm/label.h>
-#include <gtkmm/treeview.h>
-#include <gtkmm/checkbutton.h>
+
+#include <gtkmm.h>
 
 #include "util/exception.h"
 #include "util/helpers.h"

--- a/src/gui/gtkcolumnsbase.h
+++ b/src/gui/gtkcolumnsbase.h
@@ -1,14 +1,12 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GTK_COLUMNS_BASE_HEADER
 #define GTK_COLUMNS_BASE_HEADER
@@ -16,8 +14,9 @@
 #include <vector>
 #include <string>
 #include <utility>
-#include <gdkmm/pixbuf.h>
-#include <gtkmm/treeview.h>
+
+#include <gdkmm.h>
+#include <gtkmm.h>
 
 class GtkColumnOptions
 {

--- a/src/gui/gtkconfwidgets.cc
+++ b/src/gui/gtkconfwidgets.cc
@@ -1,3 +1,13 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <iostream>
 
 #include "bits/config.h"
@@ -91,7 +101,7 @@ GtkConfComboBox::append_conf_row (std::string const& text,
     std::string const& value)
 {
   this->values.push_back(value);
-  this->append_text(text);
+  this->append(text);
 
   if (value == this->value->get_string())
     this->set_active((int)this->values.size() - 1);

--- a/src/gui/gtkconfwidgets.h
+++ b/src/gui/gtkconfwidgets.h
@@ -1,25 +1,19 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GTK_CONF_WIDGETS_HEADER
 #define GTK_CONF_WIDGETS_HEADER
 
 #include <string>
-#include <gtkmm/filechooserbutton.h>
-#include <gtkmm/checkbutton.h>
-#include <gtkmm/entry.h>
-#include <gtkmm/combobox.h>
-#include <gtkmm/liststore.h>
-#include <gtkmm/comboboxtext.h>
+
+#include <gtkmm.h>
 
 #include "bits/config.h"
 

--- a/src/gui/gtkdefines.h
+++ b/src/gui/gtkdefines.h
@@ -1,22 +1,19 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GTK_DEFINES_HEADER
 #define GTK_DEFINES_HEADER
 
-#define MK_VBOX Gtk::manage(new Gtk::VBox(false, 5))
-#define MK_HBOX Gtk::manage(new Gtk::HBox(false, 5))
-#define MK_VBOX0 Gtk::manage(new Gtk::VBox(false, 0))
-#define MK_HBOX0 Gtk::manage(new Gtk::HBox(false, 0))
+#define MK_BOX0 Gtk::manage(new Gtk::Box)
+#define MK_VBOX(spacing) Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, spacing))
+#define MK_HBOX(spacing) Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, spacing))
 #define MK_FRAME(str) Gtk::manage(new Gtk::Frame(str))
 #define MK_FRAME0 Gtk::manage(new Gtk::Frame)
 #define MK_LABEL(str) Gtk::manage(new Gtk::Label(str))
@@ -31,6 +28,7 @@
 #define MK_NOTEBOOK Gtk::manage(new Gtk::Notebook)
 #define MK_ENTRY Gtk::manage(new Gtk::Entry);
 #define MK_IMG(id,size) Gtk::manage(new Gtk::Image(id, size))
+#define MK_IMG0 Gtk::manage(new Gtk::Image)
 #define MK_IMG_PB(pixbuf) Gtk::manage(new Gtk::Image(pixbuf))
 #define MK_TABLE(rows,cols) Gtk::manage(new Gtk::Table(rows, cols, false))
 #define MK_RADIO(label) Gtk::manage(new Gtk::RadioButton(label));

--- a/src/gui/gtkdownloader.cc
+++ b/src/gui/gtkdownloader.cc
@@ -1,9 +1,14 @@
-#include <gtkmm/button.h>
-#include <gtkmm/stock.h>
-#include <gtkmm/image.h>
-#include <gtkmm/table.h>
-#include <gtkmm/main.h>
-#include <gtkmm/box.h>
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
+#include <gtkmm.h>
 
 #include "util/helpers.h"
 #include "net/http.h"
@@ -16,12 +21,12 @@ GtkDownloader::GtkDownloader (void)
   this->asynchttp = 0;
   this->progressbar.set_text(" ");
 
-  Gtk::HBox* filename_box = MK_HBOX;
+  Gtk::Box* filename_box = MK_HBOX(5);
   filename_box->pack_start(*MK_LABEL("Downloading:"), false, false, 0);
   filename_box->pack_start(this->filename_label, false, false, 0);
 
   Gtk::Button* cancel_but = MK_BUT0;
-  cancel_but->set_image(*MK_IMG(Gtk::Stock::CANCEL, Gtk::ICON_SIZE_MENU));
+  cancel_but->set_image_from_icon_name("gtk-cancel", Gtk::ICON_SIZE_MENU);
   cancel_but->set_relief(Gtk::RELIEF_NONE);
 
   Gtk::Table* main_table = MK_TABLE(2, 1);

--- a/src/gui/gtkdownloader.h
+++ b/src/gui/gtkdownloader.h
@@ -1,23 +1,20 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GTK_DOWNLOADER_HEADER
 #define GTK_DOWNLOADER_HEADER
 
 #include <string>
 #include <vector>
-#include <gtkmm/label.h>
-#include <gtkmm/frame.h>
-#include <gtkmm/progressbar.h>
+
+#include <gtkmm.h>
 
 #include "net/asynchttp.h"
 

--- a/src/gui/gtkhelpers.cc
+++ b/src/gui/gtkhelpers.cc
@@ -1,6 +1,18 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <string>
 #include <sstream>
-#include <gtkmm/image.h>
+
+#include <glibmm.h>
+#include <gtkmm.h>
 
 #include "util/helpers.h"
 #include "api/evetime.h"
@@ -75,18 +87,18 @@ GtkHelpers::create_tooltip (Glib::RefPtr<Gtk::Tooltip> const& tooltip,
       ss << EveTime::get_string_for_timediff(time_remaining, false) << "\n";
     }
 
-    for (int level = cskill->level + 2; level <= 5; level++) 
+    for (int level = cskill->level + 2; level <= 5; level++)
     {
       time_remaining = (time_t)(3600.0
         * (double)(ApiCharSheet::calc_dest_sp(
-        level - 1, cskill->details->rank) 
+        level - 1, cskill->details->rank)
         - ApiCharSheet::calc_start_sp(level - 1,
         cskill->details->rank)) / spph);
-      ss << "Training time to level " 
+      ss << "Training time to level "
         << Helpers::get_roman_from_int(level) << ": "
         << EveTime::get_string_for_timediff(time_remaining, false) << "\n";
     }
-    
+
     if (completed != 0.0)
       ss << "Completed: " << Helpers::get_string_from_double
           (completed * 100.0, 2) << "%\n";
@@ -170,7 +182,7 @@ GtkHelpers::create_tooltip_from_view (int x, int y,
 
 /* ---------------------------------------------------------------- */
 
-std::string
+Glib::ustring
 GtkHelpers::locale_to_utf8 (Glib::ustring const& opsys_string)
 {
   /* We don't throw the error further away, we'll handle it here. */

--- a/src/gui/gtkhelpers.h
+++ b/src/gui/gtkhelpers.h
@@ -13,9 +13,8 @@
 #ifndef GTK_HELPERS_HEADER
 #define GTK_HELPERS_HEADER
 
-#include <gtkmm/tooltip.h>
-#include <gtkmm/treeview.h>
-#include <gtkmm/treemodel.h>
+#include <glibmm.h>
+#include <gtkmm.h>
 
 #include "api/apiskilltree.h"
 #include "api/apicharsheet.h"
@@ -36,7 +35,7 @@ class GtkHelpers
         Glib::RefPtr<Gtk::TreeModel> store,
         Gtk::TreeModelColumn<ApiElement const*> col);
 
-    static std::string locale_to_utf8 (Glib::ustring const& opsys_string);
+    static Glib::ustring locale_to_utf8 (Glib::ustring const& opsys_string);
 };
 
 #endif /* GTK_HELPERS_HEADER */

--- a/src/gui/gtkinfodisplay.cc
+++ b/src/gui/gtkinfodisplay.cc
@@ -1,8 +1,14 @@
-#include <gtkmm/scrolledwindow.h>
-#include <gtkmm/button.h>
-#include <gtkmm/separator.h>
-#include <gtkmm/stock.h>
-#include <gtkmm/frame.h>
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
+#include <gtkmm.h>
 
 #include "api/evetime.h"
 #include "util/exception.h"
@@ -11,26 +17,24 @@
 #include "gtkinfodisplay.h"
 
 GtkInfoDisplay::GtkInfoDisplay (InfoDisplayStyle style)
-  : Gtk::VBox(false, 0)
+  : Gtk::Box(Gtk::ORIENTATION_VERTICAL, 0)
 {
-  this->text.set_alignment(Gtk::ALIGN_LEFT);
+  this->text.set_halign(Gtk::ALIGN_START);
 
-  this->info_but.set_image(*Gtk::manage(new Gtk::Image
-        (Gtk::Stock::FIND, Gtk::ICON_SIZE_MENU)));
+  this->info_but.set_image_from_icon_name("edit-find", Gtk::ICON_SIZE_MENU);
   this->info_but.set_relief(Gtk::RELIEF_NONE);
   this->info_but.set_tooltip_text("Detailed information");
 
   Gtk::Button* close_but = MK_BUT0;
-  close_but->set_image(*Gtk::manage(new Gtk::Image
-        (Gtk::Stock::CLOSE, Gtk::ICON_SIZE_MENU)));
+  close_but->set_image_from_icon_name("window-close", Gtk::ICON_SIZE_MENU);
   close_but->set_relief(Gtk::RELIEF_NONE);
   close_but->set_tooltip_text("Hide message box");
 
-  Gtk::HBox* button_box = MK_HBOX0;
+  Gtk::Box* button_box = MK_HBOX(0);
   button_box->pack_start(this->info_but, false, false, 0);
   button_box->pack_start(*close_but, false, false, 0);
 
-  Gtk::HBox* item_box = MK_HBOX;
+  Gtk::Box* item_box = MK_HBOX(5);
   item_box->pack_start(this->icon, false, false, 0);
   item_box->pack_start(this->text, true, true, 0);
   item_box->pack_start(*button_box, false, false, 0);
@@ -70,14 +74,14 @@ GtkInfoDisplay::append (InfoItem const& item)
   switch (item.type)
   {
     case INFO_NOTIFICATION:
-      this->icon.set(Gtk::Stock::DIALOG_INFO, Gtk::ICON_SIZE_BUTTON);
+      this->icon.set_from_icon_name("dialog-information", Gtk::ICON_SIZE_MENU);
       break;
     case INFO_WARNING:
-      this->icon.set(Gtk::Stock::DIALOG_WARNING, Gtk::ICON_SIZE_BUTTON);
+      this->icon.set_from_icon_name("dialog-warning", Gtk::ICON_SIZE_MENU);
       break;
     default:
     case INFO_ERROR:
-      this->icon.set(Gtk::Stock::DIALOG_ERROR, Gtk::ICON_SIZE_BUTTON);
+      this->icon.set_from_icon_name("dialog-error", Gtk::ICON_SIZE_MENU);
       break;
   }
 
@@ -107,17 +111,18 @@ GtkInfoDisplay::show_info_log (void)
 
 GuiInfoDisplayLog::GuiInfoDisplayLog (std::vector<InfoItem> const& log)
   : log(log),
-    prev_but(Gtk::Stock::GO_BACK),
-    next_but(Gtk::Stock::GO_FORWARD),
+    prev_but("_Back"),
+    next_but("_Forward"),
     text_buffer(Gtk::TextBuffer::create()),
     text_view(text_buffer)
 {
   if (log.size() == 0)
     throw Exception("Need log entries to display!");
 
-  Gtk::Button* close_but = MK_BUT(Gtk::Stock::CLOSE);
+  Gtk::Button* close_but = MK_BUT0;
+  close_but->set_image_from_icon_name("window-close", Gtk::ICON_SIZE_BUTTON);
 
-  Gtk::HBox* button_box = MK_HBOX;
+  Gtk::Box* button_box = MK_HBOX(5);
   button_box->pack_start(this->prev_but, false, false, 0);
   button_box->pack_start(this->next_but, false, false, 0);
   button_box->pack_start(*MK_HSEP, true, true, 0);
@@ -128,11 +133,11 @@ GuiInfoDisplayLog::GuiInfoDisplayLog (std::vector<InfoItem> const& log)
   scwin->add(this->text_view);
   scwin->set_shadow_type(Gtk::SHADOW_ETCHED_IN);
 
-  this->message.set_alignment(Gtk::ALIGN_LEFT);
+  this->message.set_halign(Gtk::ALIGN_START);
   this->text_view.set_editable(false);
   this->text_view.set_wrap_mode(Gtk::WRAP_WORD);
 
-  Gtk::VBox* main_box = MK_VBOX;
+  Gtk::Box* main_box = MK_VBOX(5);
   main_box->set_border_width(5);
   main_box->pack_start(this->message, false, false, 0);
   main_box->pack_start(*scwin, true, true, 0);

--- a/src/gui/gtkinfodisplay.h
+++ b/src/gui/gtkinfodisplay.h
@@ -14,11 +14,8 @@
 #define GTK_INFO_DISPLAY
 
 #include <string>
-#include <gtkmm/label.h>
-#include <gtkmm/image.h>
-#include <gtkmm/box.h>
-#include <gtkmm/textbuffer.h>
-#include <gtkmm/textview.h>
+
+#include <gtkmm.h>
 
 #include "winbase.h"
 
@@ -54,7 +51,7 @@ class InfoItem
 
 /* ---------------------------------------------------------------- */
 
-class GtkInfoDisplay : public Gtk::VBox
+class GtkInfoDisplay : public Gtk::Box
 {
   private:
     std::vector<InfoItem> log;

--- a/src/gui/gtkitembrowser.cc
+++ b/src/gui/gtkitembrowser.cc
@@ -1,6 +1,16 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <iostream>
-#include <gtkmm/stock.h>
-#include <gtkmm/scrolledwindow.h>
+
+#include <gtkmm.h>
 
 #include "util/helpers.h"
 #include "bits/config.h"
@@ -164,32 +174,32 @@ enum ComboBoxSkillFilterAttribute
 };
 
 GtkSkillBrowser::GtkSkillBrowser (void)
-  : Gtk::VBox(false, 5)
+  : Gtk::Box(Gtk::ORIENTATION_VERTICAL, 5)
 {
   this->store->set_sort_column(this->cols.name, Gtk::SORT_ASCENDING);
 
-  this->filter_cb.append_text("Show all skills");
-  this->filter_cb.append_text("Only show unknown skills");
-  this->filter_cb.append_text("Only show partial skills");
-  this->filter_cb.append_text("Only show enabled skills");
-  this->filter_cb.append_text("Only show known skills");
-  this->filter_cb.append_text("Only show known skills not at V");
+  this->filter_cb.append("Show all skills");
+  this->filter_cb.append("Only show unknown skills");
+  this->filter_cb.append("Only show partial skills");
+  this->filter_cb.append("Only show enabled skills");
+  this->filter_cb.append("Only show known skills");
+  this->filter_cb.append("Only show known skills not at V");
   this->filter_cb.set_active(0);
 
-  this->primary_cb.append_text("Any");
-  this->primary_cb.append_text("Intelligence");
-  this->primary_cb.append_text("Memory");
-  this->primary_cb.append_text("Charisma");
-  this->primary_cb.append_text("Perception");
-  this->primary_cb.append_text("Willpower");
+  this->primary_cb.append("Any");
+  this->primary_cb.append("Intelligence");
+  this->primary_cb.append("Memory");
+  this->primary_cb.append("Charisma");
+  this->primary_cb.append("Perception");
+  this->primary_cb.append("Willpower");
   this->primary_cb.set_active(0);
 
-  this->secondary_cb.append_text("Any");
-  this->secondary_cb.append_text("Intelligence");
-  this->secondary_cb.append_text("Memory");
-  this->secondary_cb.append_text("Charisma");
-  this->secondary_cb.append_text("Perception");
-  this->secondary_cb.append_text("Willpower");
+  this->secondary_cb.append("Any");
+  this->secondary_cb.append("Intelligence");
+  this->secondary_cb.append("Memory");
+  this->secondary_cb.append("Charisma");
+  this->secondary_cb.append("Perception");
+  this->secondary_cb.append("Willpower");
   this->secondary_cb.set_active(0);
 
   Gtk::ScrolledWindow* scwin = MK_SCWIN;
@@ -198,17 +208,17 @@ GtkSkillBrowser::GtkSkillBrowser (void)
   scwin->add(this->view);
 
   Gtk::Button* clear_filter_but = MK_BUT0;
-  clear_filter_but->set_image(*MK_IMG(Gtk::Stock::CLEAR, Gtk::ICON_SIZE_MENU));
+  clear_filter_but->set_image_from_icon_name("edit-clear", Gtk::ICON_SIZE_MENU);
   clear_filter_but->set_relief(Gtk::RELIEF_NONE);
   clear_filter_but->set_tooltip_text("Clear filter");
 
-  Gtk::HBox* filter_box = MK_HBOX;
+  Gtk::Box* filter_box = MK_HBOX(5);
   filter_box->pack_start(*MK_LABEL("Filter:"), false, false, 0);
   filter_box->pack_start(this->filter_entry, true, true, 0);
   filter_box->pack_start(*clear_filter_but, false, false, 0);
 
-  Gtk::HBox* attributes_box = MK_HBOX;
-  Gtk::HBox* attributes_label_box = MK_HBOX;
+  Gtk::Box* attributes_box = MK_HBOX(5);
+  Gtk::Box* attributes_label_box = MK_HBOX(5);
   attributes_label_box->pack_start(*MK_LABEL("Primary Attribute"), true, true, 0);
   attributes_label_box->pack_start(*MK_LABEL("Secondary Attribute"), true, true, 0);
   attributes_box->pack_start(this->primary_cb, true, true, 0);
@@ -344,7 +354,7 @@ GtkSkillBrowser::fill_store (void)
       /* Check if the skill is partially trained. */
       if (only_partial && cskill->points == cskill->points_start)
         continue;
-      
+
       /* The skill is known and already trained to level v */
       if (only_known_but_v && cskill->level == 5)
         continue;
@@ -430,13 +440,13 @@ enum ComboBoxCertFilter
 };
 
 GtkCertBrowser::GtkCertBrowser (void)
-  : Gtk::VBox(false, 5)
+  : Gtk::Box(Gtk::ORIENTATION_VERTICAL, 5)
 {
-  this->filter_cb.append_text("Show all certificates");
-  this->filter_cb.append_text("Only show claimed certs");
-  this->filter_cb.append_text("Only show claimable certs");
-  this->filter_cb.append_text("Only show partial certs");
-  this->filter_cb.append_text("Only show unknown certs");
+  this->filter_cb.append("Show all certificates");
+  this->filter_cb.append("Only show claimed certs");
+  this->filter_cb.append("Only show claimable certs");
+  this->filter_cb.append("Only show partial certs");
+  this->filter_cb.append("Only show unknown certs");
   this->filter_cb.set_active(0);
 
   Gtk::ScrolledWindow* scwin = MK_SCWIN;
@@ -445,11 +455,11 @@ GtkCertBrowser::GtkCertBrowser (void)
   scwin->add(this->view);
 
   Gtk::Button* clear_filter_but = MK_BUT0;
-  clear_filter_but->set_image(*MK_IMG(Gtk::Stock::CLEAR, Gtk::ICON_SIZE_MENU));
+  clear_filter_but->set_image_from_icon_name("edit-clear", Gtk::ICON_SIZE_MENU);
   clear_filter_but->set_relief(Gtk::RELIEF_NONE);
   clear_filter_but->set_tooltip_text("Clear filter");
 
-  Gtk::HBox* filter_box = MK_HBOX;
+  Gtk::Box* filter_box = MK_HBOX(5);
   filter_box->pack_start(*MK_LABEL("Filter:"), false, false, 0);
   filter_box->pack_start(this->filter_entry, true, true, 0);
   filter_box->pack_start(*clear_filter_but, false, false, 0);

--- a/src/gui/gtkitembrowser.h
+++ b/src/gui/gtkitembrowser.h
@@ -1,22 +1,17 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GTK_ITEM_BROWSER_HEADER
 #define GTK_ITEM_BROWSER_HEADER
 
-#include <gtkmm/box.h>
-#include <gtkmm/entry.h>
-#include <gtkmm/treestore.h>
-#include <gtkmm/comboboxtext.h>
+#include <gtkmm.h>
 
 #include "api/apicharsheet.h"
 #include "gtkplannerbase.h"
@@ -61,7 +56,7 @@ class ItemBrowserBase
 
 /* ---------------------------------------------------------------- */
 
-class GtkSkillBrowser : public ItemBrowserBase, public Gtk::VBox
+class GtkSkillBrowser : public ItemBrowserBase, public Gtk::Box
 {
   private:
     Gtk::Entry filter_entry;
@@ -80,7 +75,7 @@ class GtkSkillBrowser : public ItemBrowserBase, public Gtk::VBox
 
 /* ---------------------------------------------------------------- */
 
-class GtkCertBrowser : public ItemBrowserBase, public Gtk::VBox
+class GtkCertBrowser : public ItemBrowserBase, public Gtk::Box
 {
   protected:
     enum CertPrerequisite

--- a/src/gui/gtkitemdetails.cc
+++ b/src/gui/gtkitemdetails.cc
@@ -1,9 +1,14 @@
-#include <gtkmm/textview.h>
-#include <gtkmm/stock.h>
-#include <gtkmm/scrolledwindow.h>
-#include <gtkmm/paned.h>
-#include <gtkmm/table.h>
-#include <gtkmm/separator.h>
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
+#include <gtkmm.h>
 
 #include "util/helpers.h"
 #include "api/evetime.h"
@@ -13,13 +18,12 @@
 #include "gtkitemdetails.h"
 
 GtkItemHistory::GtkItemHistory (void)
-  : Gtk::HBox(false, 0)
+  : Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 0)
 {
   this->history_pos = 0;
 
-  this->back_but.set_image(*MK_IMG(Gtk::Stock::GO_BACK, Gtk::ICON_SIZE_MENU));
-  this->next_but.set_image(*MK_IMG(Gtk::Stock::GO_FORWARD,
-      Gtk::ICON_SIZE_MENU));
+  this->back_but.set_image_from_icon_name("go-previous", Gtk::ICON_SIZE_MENU);
+  this->next_but.set_image_from_icon_name("go-next", Gtk::ICON_SIZE_MENU);
   this->back_but.set_relief(Gtk::RELIEF_NONE);
   this->next_but.set_relief(Gtk::RELIEF_NONE);
   this->position_label.set_text("0/0");
@@ -350,11 +354,11 @@ GtkDependencyList::on_query_element_tooltip (int x, int y, bool /*key*/,
 /* ================================================================ */
 
 GtkItemDetails::GtkItemDetails (void)
-  : Gtk::VBox(false, 5)
+  : Gtk::Box(Gtk::ORIENTATION_VERTICAL, 5)
 {
   this->element = 0;
-  this->element_name.set_alignment(Gtk::ALIGN_LEFT);
-  this->element_path.set_alignment(Gtk::ALIGN_LEFT);
+  this->element_name.set_halign(Gtk::ALIGN_START);
+  this->element_path.set_halign(Gtk::ALIGN_START);
   this->element_path.set_text("No item is selected.");
 
   Gtk::Table* elem_info_table = MK_TABLE(2, 3);
@@ -401,7 +405,7 @@ GtkItemDetails::set_element (ApiElement const* elem)
 void
 GtkItemDetails::on_element_changed (ApiElement const* elem)
 {
-  if (this->details_box.children().empty())
+  if (this->details_box.get_children().empty())
   {
     this->details_box.pack_start(this->skill_details, true, true, 0);
     this->details_box.pack_start(this->cert_details, true, true, 0);
@@ -459,15 +463,16 @@ GtkItemDetails::on_element_changed (ApiElement const* elem)
 /* ================================================================ */
 
 GtkSkillDetails::GtkSkillDetails (void)
-  : Gtk::VBox(false, 5),
+  : Gtk::Box(Gtk::ORIENTATION_VERTICAL, 5),
     desc_buffer(Gtk::TextBuffer::create()),
     deps(false)
 {
-  this->skill_primary.set_alignment(Gtk::ALIGN_LEFT);
-  this->skill_secondary.set_alignment(Gtk::ALIGN_LEFT);
+  this->skill_primary.set_halign(Gtk::ALIGN_START);
+  this->skill_secondary.set_halign(Gtk::ALIGN_START);
   for (unsigned int i = 0; i < 5; ++i)
   {
-    this->skill_level[i].set_alignment(Gtk::ALIGN_LEFT, Gtk::ALIGN_TOP);
+    this->skill_level[i].set_halign(Gtk::ALIGN_START);
+    this->skill_level[i].set_valign(Gtk::ALIGN_START);
     this->skill_level[i].set_selectable(true);
   }
 
@@ -482,15 +487,16 @@ GtkSkillDetails::GtkSkillDetails (void)
 
   Gtk::Label* primary_label = MK_LABEL("Primary:");
   Gtk::Label* secondary_label = MK_LABEL("Secondary:");
-  primary_label->set_alignment(Gtk::ALIGN_LEFT);
-  secondary_label->set_alignment(Gtk::ALIGN_LEFT);
+  primary_label->set_halign(Gtk::ALIGN_START);
+  secondary_label->set_halign(Gtk::ALIGN_START);
   Gtk::Label* to_level_label[5];
   for (unsigned int i = 0; i < 5; ++i)
   {
     to_level_label[i] = Gtk::manage(new Gtk::Label);
     to_level_label[i]->set_text("To level "
         + Helpers::get_string_from_int(i + 1) + ":");
-    to_level_label[i]->set_alignment(Gtk::ALIGN_LEFT, Gtk::ALIGN_TOP);
+    to_level_label[i]->set_halign(Gtk::ALIGN_START);
+    to_level_label[i]->set_valign(Gtk::ALIGN_START);
   }
 
   Gtk::Table* details_table = Gtk::manage(new Gtk::Table(7, 3, false));

--- a/src/gui/gtkitemdetails.h
+++ b/src/gui/gtkitemdetails.h
@@ -1,23 +1,17 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GTK_ITEM_DEATILS_HEADER
 #define GTK_ITEM_DEATILS_HEADER
 
-#include <gtkmm/box.h>
-#include <gtkmm/treeview.h>
-#include <gtkmm/treestore.h>
-#include <gtkmm/textbuffer.h>
-#include <gtkmm/scrolledwindow.h>
+#include <gtkmm.h>
 
 #include "api/apiskilltree.h"
 #include "api/apicerttree.h"
@@ -33,7 +27,7 @@
  * with append_element. A signal is then fired to notify the GUI
  * to update to the new element.
  */
-class GtkItemHistory : public Gtk::HBox
+class GtkItemHistory : public Gtk::Box
 {
   private:
     std::vector<ApiElement const*> history;
@@ -116,7 +110,7 @@ class GtkDependencyList : public GtkItemDetailsBase, public Gtk::ScrolledWindow
 /* ---------------------------------------------------------------- */
 
 /* This GUI class shows details for skills. */
-class GtkSkillDetails : public GtkItemDetailsBase, public Gtk::VBox
+class GtkSkillDetails : public GtkItemDetailsBase, public Gtk::Box
 {
   private:
     /* Skill details. */
@@ -134,7 +128,7 @@ class GtkSkillDetails : public GtkItemDetailsBase, public Gtk::VBox
 /* ---------------------------------------------------------------- */
 
 /* This GUI class shows details for certificates. */
-class GtkCertDetails : public GtkItemDetailsBase, public Gtk::VBox
+class GtkCertDetails : public GtkItemDetailsBase, public Gtk::Box
 {
   private:
     Glib::RefPtr<Gtk::TextBuffer> desc_buffer;
@@ -151,7 +145,7 @@ class GtkCertDetails : public GtkItemDetailsBase, public Gtk::VBox
  * This GUI class is a container for detail GUIs. It shows the
  * icon and name of the item and displays the appropriate detail GUI.
  */
-class GtkItemDetails : public GtkItemDetailsBase, public Gtk::VBox
+class GtkItemDetails : public GtkItemDetailsBase, public Gtk::Box
 {
   private:
     ApiElement const* element;
@@ -159,7 +153,7 @@ class GtkItemDetails : public GtkItemDetailsBase, public Gtk::VBox
     Gtk::Label element_path;
     Gtk::Label element_name;
     GtkItemHistory history;
-    Gtk::VBox details_box;
+    Gtk::Box details_box;
     GtkSkillDetails skill_details;
     GtkCertDetails cert_details;
 

--- a/src/gui/gtkplannerbase.cc
+++ b/src/gui/gtkplannerbase.cc
@@ -1,7 +1,16 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <iostream>
 
-#include <gtkmm/image.h>
-#include <gtkmm/imagemenuitem.h>
+#include <gtkmm.h>
 
 #include "util/helpers.h"
 #include "imagestore.h"

--- a/src/gui/gtkplannerbase.h
+++ b/src/gui/gtkplannerbase.h
@@ -1,22 +1,17 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GTK_PLANNER_BASE_HEADER
 #define GTK_PLANNER_BASE_HEADER
 
-#include <gtkmm/treeview.h>
-#include <gtkmm/treemodel.h>
-#include <gtkmm/menu.h>
-#include <gdkmm/pixbuf.h>
+#include <gtkmm.h>
 
 #include "api/apiskilltree.h"
 #include "api/apicerttree.h"

--- a/src/gui/gtkportrait.cc
+++ b/src/gui/gtkportrait.cc
@@ -1,7 +1,18 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <sstream>
 #include <fstream>
 #include <iostream>
-#include <gtkmm/messagedialog.h>
+
+#include <gtkmm.h>
 
 #include "util/os.h"
 #include "net/http.h"

--- a/src/gui/gtkportrait.h
+++ b/src/gui/gtkportrait.h
@@ -1,22 +1,20 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GTK_PORTRAIT_HEADER
 #define GTK_PORTRAIT_HEADER
 
 #include <string>
-#include <gdkmm/pixbuf.h>
-#include <gtkmm/image.h>
-#include <gtkmm/eventbox.h>
+
+#include <gdkmm.h>
+#include <gtkmm.h>
 
 #include "net/asynchttp.h"
 

--- a/src/gui/gtkserver.cc
+++ b/src/gui/gtkserver.cc
@@ -1,6 +1,15 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <iostream>
-#include <gtkmm/stock.h>
-#include <gtkmm/label.h>
+#include <gtkmm.h>
 
 #include "util/exception.h"
 #include "util/helpers.h"
@@ -55,16 +64,16 @@ GtkServer::GtkServer (ServerPtr server)
   this->status.set_text("Fetching");
 
   this->set_col_spacings(5);
-  this->set_status_icon(Gtk::Stock::REFRESH);
+  this->set_status_icon("view-refresh");
   this->status_but.set_relief(Gtk::RELIEF_NONE);
 
   Gtk::Label* label_server = Gtk::manage(new Gtk::Label("Server:"));
 
-  label_server->set_alignment(Gtk::ALIGN_LEFT);
-  this->status_desc.set_alignment(Gtk::ALIGN_LEFT);
+  label_server->set_halign(Gtk::ALIGN_START);
+  this->status_desc.set_halign(Gtk::ALIGN_START);
 
-  this->name.set_alignment(Gtk::ALIGN_RIGHT);
-  this->status.set_alignment(Gtk::ALIGN_RIGHT);
+  this->name.set_halign(Gtk::ALIGN_END);
+  this->status.set_halign(Gtk::ALIGN_END);
 
   this->name.set_text(server->get_name());
 
@@ -90,11 +99,11 @@ GtkServer::update (void)
 {
   if (server->is_refreshing() || server->get_players() == -1)
   {
-    this->set_status_icon(Gtk::Stock::REFRESH);
+    this->set_status_icon("view-refresh");
   }
   else if (server->is_online())
   {
-    this->set_status_icon(Gtk::Stock::YES);
+    this->set_status_icon("gtk-yes");
     this->status_desc.set_text("Players:");
 
     if (server->get_players() == -2)
@@ -105,7 +114,7 @@ GtkServer::update (void)
   }
   else
   {
-    this->set_status_icon(Gtk::Stock::NO);
+    this->set_status_icon("gtk-no");
     this->status_desc.set_text("Status:");
     this->status.set_text("Offline");
   }
@@ -118,14 +127,13 @@ GtkServer::force_refresh (void)
 {
   GtkServerChecker* sc = new GtkServerChecker(this->server);
   sc->pt_create();
-  this->set_status_icon(Gtk::Stock::REFRESH);
+  this->set_status_icon("view-refresh");
 }
 
 /* ---------------------------------------------------------------- */
 
 void
-GtkServer::set_status_icon (Gtk::BuiltinStockID const& id)
+GtkServer::set_status_icon (const Glib::ustring icon_name)
 {
-  this->status_but.set_image(*Gtk::manage
-      (new Gtk::Image(id, Gtk::ICON_SIZE_BUTTON)));
+  this->status_but.set_image_from_icon_name(icon_name, Gtk::ICON_SIZE_BUTTON);
 }

--- a/src/gui/gtkserver.h
+++ b/src/gui/gtkserver.h
@@ -1,22 +1,17 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GTK_SERVER_HEADER
 #define GTK_SERVER_HEADER
 
-#include <gtkmm/table.h>
-#include <gtkmm/label.h>
-#include <gtkmm/button.h>
-#include <gtkmm/stock.h>
+#include <gtkmm.h>
 
 #include "bits/server.h"
 
@@ -31,7 +26,7 @@ class GtkServer : public Gtk::Table
     Gtk::Label status_desc;
 
     void force_refresh (void);
-    void set_status_icon (Gtk::BuiltinStockID const& id);
+    void set_status_icon (const Glib::ustring icon_name);
 
   public:
     GtkServer (ServerPtr server);

--- a/src/gui/gtkskillqueue.cc
+++ b/src/gui/gtkskillqueue.cc
@@ -1,5 +1,14 @@
-#include <gtkmm/messagedialog.h>
-#include <gtkmm/scrolledwindow.h>
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
+#include <gtkmm.h>
 
 #include "util/helpers.h"
 #include "api/evetime.h"
@@ -41,10 +50,10 @@ GtkSkillQueueViewCols::GtkSkillQueueViewCols (Gtk::TreeView* view,
   this->append_column(&this->training, GtkColumnOptions(true, false, true));
   this->append_column(&this->attribs, GtkColumnOptions(true, false, true));
 
-  this->position.get_first_cell_renderer()->set_property("xalign", 1.0f);
+  this->position.get_first_cell()->set_property("xalign", 1.0f);
   this->skill_name.set_expand(true);
-  this->start_sp.get_first_cell_renderer()->set_property("xalign", 1.0f);
-  this->end_sp.get_first_cell_renderer()->set_property("xalign", 1.0f);
+  this->start_sp.get_first_cell()->set_property("xalign", 1.0f);
+  this->end_sp.get_first_cell()->set_property("xalign", 1.0f);
 }
 
 /* ================================================================ */

--- a/src/gui/gtkskillqueue.h
+++ b/src/gui/gtkskillqueue.h
@@ -1,22 +1,19 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GTK_SKILL_QUEUE_HEADER
 #define GTK_SKILL_QUEUE_HEADER
 
 #include <string>
-#include <gtkmm/treeview.h>
-#include <gtkmm/liststore.h>
-#include <gtkmm/box.h>
+
+#include <gtkmm.h>
 
 #include "bits/character.h"
 #include "gtkcolumnsbase.h"
@@ -60,7 +57,7 @@ class GtkSkillQueueViewCols : public GtkColumnsBase
 
 /* ---------------------------------------------------------------- */
 
-class GtkSkillQueue : public Gtk::VBox
+class GtkSkillQueue : public Gtk::Box
 {
   private:
     CharacterPtr character;

--- a/src/gui/gtktrainingplan.cc
+++ b/src/gui/gtktrainingplan.cc
@@ -1,9 +1,16 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <iostream>
-#include <gtkmm/stock.h>
-#include <gtkmm/messagedialog.h>
-#include <gtkmm/entry.h>
-#include <gtkmm/table.h>
-#include <gtkmm/scrolledwindow.h>
+
+#include <gtkmm.h>
 
 #include "util/helpers.h"
 #include "api/evetime.h"
@@ -383,7 +390,7 @@ GtkSkillList::is_dependency (unsigned int index)
 /* ---------------------------------------------------------------- */
 
 OptimalData
-GtkSkillList::get_optimal_data (void) const 
+GtkSkillList::get_optimal_data (void) const
 {
   GtkSkillList plan = *this;
 
@@ -523,12 +530,12 @@ GtkTreeViewColumns::GtkTreeViewColumns (Gtk::TreeView* view,
 
   this->objective.set_resizable(false);
   Gtk::CellRendererToggle* objective_col = dynamic_cast
-      <Gtk::CellRendererToggle*>(this->objective.get_first_cell_renderer());
+      <Gtk::CellRendererToggle*>(this->objective.get_first_cell());
   objective_col->set_property("activatable", true);
 
   /* Make user notes editable. */
   ((Gtk::CellRendererText*)this->user_notes
-      .get_first_cell_renderer())->property_editable() = true;
+      .get_first_cell())->property_editable() = true;
 
   this->append_column(&this->objective, GtkColumnOptions
       (false, true, false, ImageStore::columnconf[1]));
@@ -558,19 +565,19 @@ GtkTreeViewColumns::GtkTreeViewColumns (Gtk::TreeView* view,
   this->train_duration.set_resizable(false);
   this->skill_duration.set_resizable(false);
   this->completed.set_resizable(false);
-  this->completed.get_first_cell_renderer()->set_property("xalign", 1.0f);
+  this->completed.get_first_cell()->set_property("xalign", 1.0f);
   this->attributes.set_resizable(false);
   this->est_start.set_resizable(false);
   this->est_finish.set_resizable(false);
   this->user_notes.set_resizable(true);
   this->spph.set_resizable(false);
-  this->spph.get_first_cell_renderer()->set_property("xalign", 1.0);
+  this->spph.get_first_cell()->set_property("xalign", 1.0);
 }
 
 /* ================================================================ */
 
 GtkTrainingPlan::GtkTrainingPlan (void)
-  : Gtk::VBox(false, 5),
+  : Gtk::Box(Gtk::ORIENTATION_VERTICAL, 5),
     liststore(Gtk::ListStore::create(cols)),
     treeview(liststore),
     viewcols(&treeview, &cols)
@@ -580,36 +587,29 @@ GtkTrainingPlan::GtkTrainingPlan (void)
   // DELETE is defined in winnt.h and clashes with GTK
 # undef DELETE
 #endif
-  this->delete_plan_but.set_image(*MK_IMG
-      (Gtk::Stock::DELETE, Gtk::ICON_SIZE_MENU));
-  this->create_plan_but.set_image(*MK_IMG
-      (Gtk::Stock::NEW, Gtk::ICON_SIZE_MENU));
-  this->rename_plan_but.set_image(*MK_IMG
-      (Gtk::Stock::EDIT, Gtk::ICON_SIZE_MENU));
-  this->export_plan_but.set_image(*MK_IMG
-      (Gtk::Stock::SAVE_AS, Gtk::ICON_SIZE_MENU));
-  this->import_plan_but.set_image(*MK_IMG
-      (Gtk::Stock::REVERT_TO_SAVED, Gtk::ICON_SIZE_MENU));
+  this->delete_plan_but.set_image_from_icon_name("edit-delete", Gtk::ICON_SIZE_MENU);
+  this->create_plan_but.set_image_from_icon_name("document-new", Gtk::ICON_SIZE_MENU);
+  this->rename_plan_but.set_image_from_icon_name("gtk-edit", Gtk::ICON_SIZE_MENU);
+  this->export_plan_but.set_image_from_icon_name("document-save-as", Gtk::ICON_SIZE_MENU);
+  this->import_plan_but.set_image_from_icon_name("document-revert", Gtk::ICON_SIZE_MENU);
   //this->delete_plan_but.set_relief(Gtk::RELIEF_NONE);
   //this->create_plan_but.set_relief(Gtk::RELIEF_NONE);
   //this->rename_plan_but.set_relief(Gtk::RELIEF_NONE);
   //this->export_plan_but.set_label("Export");
   //this->import_plan_but.set_label("Import");
 
-  this->clean_plan_but.set_image(*MK_IMG
-      (Gtk::Stock::CLEAR, Gtk::ICON_SIZE_MENU));
+  this->clean_plan_but.set_image_from_icon_name("edit-clear", Gtk::ICON_SIZE_MENU);
   this->clean_plan_but.set_label("Clean finished");
   this->column_conf_but.set_image(*MK_IMG_PB(ImageStore::columnconf[0]));
   this->column_conf_but.set_label("Configure columns");
-  this->optimize_att_but.set_image(*MK_IMG
-      (Gtk::Stock::NETWORK, Gtk::ICON_SIZE_MENU));
+  this->clean_plan_but.set_image_from_icon_name("network-workgroup", Gtk::ICON_SIZE_MENU);
 
   this->total_time.set_text("n/a");
-  this->total_time.set_alignment(Gtk::ALIGN_LEFT);
+  this->total_time.set_halign(Gtk::ALIGN_START);
   this->optimize_att_but.set_label("Optimize attributes");
 
   this->optimal_time.set_text("n/a");
-  this->optimal_time.set_alignment(Gtk::ALIGN_LEFT);
+  this->optimal_time.set_halign(Gtk::ALIGN_START);
 
   this->reorder_new_index = -1;
   //this->clean_plan_but.set_label("Clean up");
@@ -631,15 +631,15 @@ GtkTrainingPlan::GtkTrainingPlan (void)
   scwin->set_shadow_type(Gtk::SHADOW_ETCHED_IN);
 
   /* Create GUI. */
-  Gtk::HBox* button_box = MK_HBOX;
+  Gtk::Box* button_box = MK_HBOX(5);
   button_box->pack_start(this->clean_plan_but, false, false, 0);
   button_box->pack_start(this->column_conf_but, false, false, 0);
   button_box->pack_start(this->optimize_att_but, false, false, 0);
 
-  Gtk::VBox* button_vbox = MK_VBOX;
+  Gtk::Box* button_vbox = MK_VBOX(5);
   button_vbox->pack_end(*button_box, false, false, 0);
 
-  Gtk::HBox* section_selection_box = MK_HBOX0;
+  Gtk::Box* section_selection_box = MK_HBOX(0);
   section_selection_box->pack_start(this->plan_selection, true, true, 0);
   section_selection_box->pack_start(this->rename_plan_but, false, false, 0);
   section_selection_box->pack_start(this->create_plan_but, false, false, 0);
@@ -648,11 +648,11 @@ GtkTrainingPlan::GtkTrainingPlan (void)
   Gtk::Label* select_label = MK_LABEL("Training plan:");
   Gtk::Label* time_label = MK_LABEL("Total time:");
   Gtk::Label* optimal_time_label = MK_LABEL("Optimal time:");
-  select_label->set_alignment(Gtk::ALIGN_LEFT);
-  time_label->set_alignment(Gtk::ALIGN_LEFT);
-  optimal_time_label->set_alignment(Gtk::ALIGN_LEFT);
+  select_label->set_halign(Gtk::ALIGN_START);
+  time_label->set_halign(Gtk::ALIGN_START);
+  optimal_time_label->set_halign(Gtk::ALIGN_START);
 
-  Gtk::HBox* time_file_ops = MK_HBOX0;
+  Gtk::Box* time_file_ops = MK_HBOX(0);
   time_file_ops->pack_start(this->total_time, false, false, 0);
   time_file_ops->pack_end(this->import_plan_but, false, false, 0);
   time_file_ops->pack_end(this->export_plan_but, false, false, 0);
@@ -725,7 +725,7 @@ GtkTrainingPlan::GtkTrainingPlan (void)
   this->viewcols.signal_editing_canceled().connect(sigc::mem_fun
       (this, &GtkTrainingPlan::on_user_notes_editing_canceled));
   dynamic_cast<Gtk::CellRendererToggle*>(this->viewcols.objective
-      .get_first_cell_renderer())->signal_toggled().connect(sigc::mem_fun
+      .get_first_cell())->signal_toggled().connect(sigc::mem_fun
       (*this, &GtkTrainingPlan::on_objective_toggled));
   this->treeview.signal_query_tooltip().connect(sigc::mem_fun
       (*this, &GtkTrainingPlan::on_query_skillview_tooltip));
@@ -1118,11 +1118,11 @@ GtkTrainingPlan::on_create_skill_plan (void)
       "don't need it anymore.");
   dialog.set_title("Create plan - GtkEveMon");
   dialog.set_default_response(Gtk::RESPONSE_OK);
-  Gtk::VBox* dialog_box = dialog.get_vbox();
+  Gtk::Box* dialog_box = dialog.get_content_area();
 
   Gtk::Entry new_name_entry;
   new_name_entry.set_activates_default(true);
-  Gtk::HBox* entry_box = MK_HBOX;
+  Gtk::Box* entry_box = MK_HBOX(5);
   entry_box->pack_start(*MK_LABEL("Plan name:"), false, false, 0);
   entry_box->pack_start(new_name_entry, true, true, 0);
   dialog_box->pack_start(*entry_box, false, false, 0);
@@ -1159,13 +1159,13 @@ GtkTrainingPlan::on_rename_skill_plan (void)
   dialog.set_secondary_text("Remember to always fly safe!");
   dialog.set_title("Rename plan - GtkEveMon");
   dialog.set_default_response(Gtk::RESPONSE_OK);
-  Gtk::VBox* dialog_box = dialog.get_vbox();
+  Gtk::Box* dialog_box = dialog.get_content_area();
 
   Gtk::Entry new_name_entry;
   new_name_entry.set_activates_default(true);
   new_name_entry.set_text(old_text);
   new_name_entry.select_region(0, -1);
-  Gtk::HBox* entry_box = MK_HBOX;
+  Gtk::Box* entry_box = MK_HBOX(5);
   entry_box->pack_start(*MK_LABEL("Plan name:"), false, false, 0);
   entry_box->pack_start(new_name_entry, true, true, 0);
   dialog_box->pack_start(*entry_box, false, false, 0);
@@ -1327,7 +1327,7 @@ GtkTrainingPlan::on_import_plan (void)
   dialog_tbl->attach(*label_new, 0, 1, 2, 3, Gtk::SHRINK | Gtk::FILL);
   dialog_tbl->attach(*entry_new, 1, 2, 2, 3, Gtk::EXPAND | Gtk::FILL);
 
-  Gtk::VBox* dialog_box = dialog.get_vbox();
+  Gtk::Box* dialog_box = dialog.get_content_area();
   dialog_box->pack_start(*dialog_tbl, false, false, 0);
   dialog_box->show_all();
 
@@ -1357,20 +1357,20 @@ GtkTrainingPlan::on_import_plan (void)
   /* Open file chooser dialog. */
   Gtk::FileChooserDialog fcd(*toplevel, "Export skill plan...",
       Gtk::FILE_CHOOSER_ACTION_SAVE);
-  fcd.add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-  fcd.add_button(Gtk::Stock::OPEN, Gtk::RESPONSE_OK);
+  fcd.add_button("Cancel", Gtk::RESPONSE_CANCEL);
+  fcd.add_button("Open", Gtk::RESPONSE_OK);
 
   {
-    Gtk::FileFilter filter;
-    filter.add_pattern("*.emp");
-    filter.set_name("EveMon Plan (*.emp)");
+    Glib::RefPtr<Gtk::FileFilter> filter = Gtk::FileFilter::create();
+    filter->add_pattern("*.emp");
+    filter->set_name("EveMon Plan (*.emp)");
     fcd.add_filter(filter);
   }
 
   {
-    Gtk::FileFilter filter;
-    filter.add_pattern("*.xml");
-    filter.set_name("EveMon Uncompressed Plan (*.xml)");
+    Glib::RefPtr<Gtk::FileFilter> filter = Gtk::FileFilter::create();
+    filter->add_pattern("*.xml");
+    filter->set_name("EveMon Uncompressed Plan (*.xml)");
     fcd.add_filter(filter);
   }
 
@@ -1425,24 +1425,24 @@ GtkTrainingPlan::on_export_plan (void)
 
   Gtk::FileChooserDialog fcb(*toplevel, "Export skill plan...",
       Gtk::FILE_CHOOSER_ACTION_SAVE);
-  fcb.add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-  fcb.add_button(Gtk::Stock::SAVE, Gtk::RESPONSE_OK);
+  fcb.add_button("Cancel", Gtk::RESPONSE_CANCEL);
+  fcb.add_button("Save", Gtk::RESPONSE_OK);
   fcb.set_do_overwrite_confirmation(true);
 
 #define PLAN_FILTER_EMP "EveMon Plan (*.emp)"
 #define PLAN_FILTER_XML "EveMon Uncompressed Plan (*.xml)"
 
   {
-    Gtk::FileFilter filter;
-    filter.add_pattern("*.emp");
-    filter.set_name(PLAN_FILTER_EMP);
+    Glib::RefPtr<Gtk::FileFilter> filter = Gtk::FileFilter::create();
+    filter->add_pattern("*.emp");
+    filter->set_name(PLAN_FILTER_EMP);
     fcb.add_filter(filter);
   }
 
   {
-    Gtk::FileFilter filter;
-    filter.add_pattern("*.xml");
-    filter.set_name(PLAN_FILTER_XML);
+    Glib::RefPtr<Gtk::FileFilter> filter = Gtk::FileFilter::create();
+    filter->add_pattern("*.xml");
+    filter->set_name(PLAN_FILTER_XML);
     fcb.add_filter(filter);
   }
 
@@ -1459,7 +1459,7 @@ GtkTrainingPlan::on_export_plan (void)
 
     /* FIXME: Fetch extension from filter. */
     #if 0
-    Gtk::FileFilter* filter = fcb.get_filter();
+    Glib::RefPtr<Gtk::FileFilter> filter = fcb.get_filter();
     if (filter->get_name() == PLAN_FILTER_XML)
       extension = ".xml";
     #endif

--- a/src/gui/gtktrainingplan.h
+++ b/src/gui/gtktrainingplan.h
@@ -1,23 +1,17 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GTK_TRAINING_PLAN
 #define GTK_TRAINING_PLAN
 
-#include <gtkmm/button.h>
-#include <gtkmm/label.h>
-#include <gtkmm/box.h>
-#include <gtkmm/treeview.h>
-#include <gtkmm/liststore.h>
+#include <gtkmm.h>
 
 #include "bits/config.h"
 #include "bits/character.h"
@@ -172,7 +166,7 @@ class GtkTreeViewColumns : public GtkColumnsBase
 
 /* ---------------------------------------------------------------- */
 
-class GtkTrainingPlan : public Gtk::VBox
+class GtkTrainingPlan : public Gtk::Box
 {
   private:
     CharacterPtr character;
@@ -275,19 +269,19 @@ inline GtkTreeViewColumns::CellEditedSignal
 GtkTreeViewColumns::signal_user_notes_changed (void)
 {
   return ((Gtk::CellRendererText*)this->user_notes
-      .get_first_cell_renderer())->signal_edited();
+      .get_first_cell())->signal_edited();
 }
 
 inline GtkTreeViewColumns::CellStartEditingSignal
 GtkTreeViewColumns::signal_editing_started (void)
 {
-  return this->user_notes.get_first_cell_renderer()->signal_editing_started();
+  return this->user_notes.get_first_cell()->signal_editing_started();
 }
 
 inline GtkTreeViewColumns::CellEditCanceledSignal
 GtkTreeViewColumns::signal_editing_canceled (void)
 {
-  return this->user_notes.get_first_cell_renderer()->signal_editing_canceled();
+  return this->user_notes.get_first_cell()->signal_editing_canceled();
 }
 
 inline sigc::signal<void, ApiSkill const*>&

--- a/src/gui/guiaboutdialog.cc
+++ b/src/gui/guiaboutdialog.cc
@@ -1,11 +1,16 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <iostream>
 
-#include <gtkmm/stock.h>
-#include <gtkmm/box.h>
-#include <gtkmm/button.h>
-#include <gtkmm/label.h>
-#include <gtkmm/image.h>
-#include <gtkmm/frame.h>
+#include <gtkmm.h>
 
 #include "net/asynchttp.h"
 #include "bits/config.h"
@@ -22,14 +27,14 @@ GuiAboutDialog::GuiAboutDialog (void)
   logo_frame->set_shadow_type(Gtk::SHADOW_IN);
 
   Gtk::Label* title_label = MK_LABEL0;
-  title_label->set_alignment(Gtk::ALIGN_LEFT);
+  title_label->set_halign(Gtk::ALIGN_START);
   title_label->set_text("<b>GtkEveMon - a skill monitor for Linux</b>");
   title_label->set_use_markup(true);
 
   Gtk::Label* info_label = MK_LABEL0;
   info_label->set_line_wrap(true);
   info_label->set_justify(Gtk::JUSTIFY_LEFT);
-  info_label->set_alignment(Gtk::ALIGN_LEFT);
+  info_label->set_halign(Gtk::ALIGN_START);
   info_label->set_text(
       "GtkEveMon is a skill monitoring standalone\n"
       "application for GNU/Linux systems. With GtkEveMon\n"
@@ -42,21 +47,21 @@ GuiAboutDialog::GuiAboutDialog (void)
       "GtkEveMon " GTKEVEMON_VERSION_STR);
   info_label->set_use_markup(true);
 
-  Gtk::Button* close_but = MK_BUT(Gtk::Stock::CLOSE);
-  Gtk::HBox* button_box = MK_HBOX;
+  Gtk::Button* close_but = MK_BUT("Close");
+  Gtk::Box* button_box = MK_HBOX(5);
   button_box->pack_end(*close_but, false, false, 0);
 
-  Gtk::VBox* about_label_box = MK_VBOX;
+  Gtk::Box* about_label_box = MK_VBOX(5);
   about_label_box->pack_start(*title_label, false, false, 0);
   about_label_box->pack_start(*info_label, false, false, 0);
   about_label_box->pack_end(*button_box, false, false, 0);
 
-  Gtk::HBox* logo_text_box = MK_HBOX;
+  Gtk::Box* logo_text_box = MK_HBOX(5);
   logo_text_box->set_spacing(10);
   logo_text_box->pack_start(*logo_frame, false, false, 0);
   logo_text_box->pack_start(*about_label_box, true, true, 0);
 
-  Gtk::VBox* main_box = MK_VBOX;
+  Gtk::Box* main_box = MK_VBOX(5);
   main_box->set_border_width(5);
   main_box->pack_start(*logo_text_box, false, false, 0);
 

--- a/src/gui/guiaboutdialog.h
+++ b/src/gui/guiaboutdialog.h
@@ -1,14 +1,12 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GUI_ABOUT_DIALOG_HEADER
 #define GUI_ABOUT_DIALOG_HEADER

--- a/src/gui/guicharexport.cc
+++ b/src/gui/guicharexport.cc
@@ -1,13 +1,18 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <iostream>
 #include <iomanip>
 #include <sstream>
-#include <gtkmm/scrolledwindow.h>
-#include <gtkmm/box.h>
-#include <gtkmm/button.h>
-#include <gtkmm/separator.h>
-#include <gtkmm/label.h>
-#include <gtkmm/textview.h>
-#include <gtkmm/stock.h>
+
+#include <gtkmm.h>
 
 #include "util/helpers.h"
 #include "gtkdefines.h"
@@ -42,8 +47,9 @@ GtkExportPane::set_text (Glib::ustring const& text)
 
 GuiCharExport::GuiCharExport (ApiCharSheetPtr charsheet)
 {
-  Gtk::Button* close_but = MK_BUT(Gtk::Stock::CLOSE);
-  Gtk::HBox* button_box = MK_HBOX;
+  Gtk::Button* close_but = MK_BUT0;
+  close_but->set_image_from_icon_name("widnow-close", Gtk::ICON_SIZE_BUTTON);
+  Gtk::Box* button_box = MK_HBOX(5);
   button_box->pack_start(*MK_HSEP, true, true, 0);
   button_box->pack_start(*close_but, false, false, 0);
 
@@ -54,7 +60,7 @@ GuiCharExport::GuiCharExport (ApiCharSheetPtr charsheet)
   notebook->append_page(*eft_export, "EFT", false);
   notebook->append_page(*bbc_export, "BB-Code", false);
 
-  Gtk::VBox* main_box = MK_VBOX;
+  Gtk::Box* main_box = MK_VBOX(5);
   main_box->set_border_width(5);
   main_box->pack_start(*notebook, true, true, 0);
   main_box->pack_start(*button_box, false, false, 0);

--- a/src/gui/guicharexport.h
+++ b/src/gui/guicharexport.h
@@ -1,28 +1,25 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GUI_CHAR_EXPORT_HEADER
 #define GUI_CHAR_EXPORT_HEADER
 
 #include <map>
 #include <string>
-#include <gtkmm/box.h>
-#include <gtkmm/notebook.h>
-#include <gtkmm/textbuffer.h>
+
+#include <gtkmm.h>
 
 #include "api/apicharsheet.h"
 #include "winbase.h"
 
-class GtkExportPane : public Gtk::VBox
+class GtkExportPane : public Gtk::Box
 {
   private:
     Glib::RefPtr<Gtk::TextBuffer> text_buf;

--- a/src/gui/guiconfiguration.cc
+++ b/src/gui/guiconfiguration.cc
@@ -1,16 +1,16 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <iostream>
-#include <gtkmm/table.h>
-#include <gtkmm/stock.h>
-#include <gtkmm/separator.h>
-#include <gtkmm/scrolledwindow.h>
-#include <gtkmm/filechooserdialog.h>
-#include <gtkmm/box.h>
-#include <gtkmm/frame.h>
-#include <gtkmm/button.h>
-#include <gtkmm/image.h>
-#include <gtkmm/label.h>
-#include <gtkmm/textview.h>
-#include <gtkmm/notebook.h>
+
+#include <gtkmm.h>
 
 #include "util/helpers.h"
 #include "defines.h"
@@ -26,7 +26,7 @@ GuiConfiguration::GuiConfiguration (void)
   this->tray_usage.append_conf_row("Minimize to tray", "minimize");
   this->tray_usage.append_conf_row("Always stay in tray", "always");
 
-  Gtk::HBox* misc_tray_box = MK_HBOX;
+  Gtk::Box* misc_tray_box = MK_HBOX(5);
   misc_tray_box->pack_start(*MK_LABEL("Tray usage:"), false, false, 0);
   misc_tray_box->pack_start(this->tray_usage, true, true, 0);
 
@@ -52,7 +52,7 @@ GuiConfiguration::GuiConfiguration (void)
       (new GtkConfCheckButton("Automatically check for updated data files",
       false, "updater.autocheck"));
 
-  Gtk::VBox* misc_cb_box = MK_VBOX0;
+  Gtk::Box* misc_cb_box = MK_VBOX(0);
   misc_cb_box->pack_start(*misc_min_on_close_cb, false, false, 0);
   misc_cb_box->pack_start(*misc_detailed_tray_tt_cb, false, false, 0);
   misc_cb_box->pack_start(*misc_verbose_wintitle_cb, false, false, 0);
@@ -61,7 +61,7 @@ GuiConfiguration::GuiConfiguration (void)
   misc_cb_box->pack_start(*misc_show_unpublished_skills_cb, false, false, 0);
   misc_cb_box->pack_start(*misc_updater_autocheck, false, false, 0);
 
-  Gtk::VBox* page_misc = MK_VBOX;
+  Gtk::Box* page_misc = MK_VBOX(5);
   page_misc->set_border_width(5);
   page_misc->pack_start(*misc_tray_box, false, false, 0);
   page_misc->pack_start(*misc_cb_box, false, false, 0);
@@ -72,7 +72,7 @@ GuiConfiguration::GuiConfiguration (void)
       "specify more than one command, GtkEveMon will prompt which command "
       "to execute.\n"
       "Note that \"~\" does not work as home directory.");
-  launch_info_label->set_alignment(Gtk::ALIGN_LEFT);
+  launch_info_label->set_halign(Gtk::ALIGN_START);
   launch_info_label->set_line_wrap(true);
 
   Gtk::Table* launch_table = Gtk::manage(new Gtk::Table
@@ -96,7 +96,7 @@ GuiConfiguration::GuiConfiguration (void)
         (new GtkConfTextEntry("settings." + key));
 
     Gtk::Button* eve_cmd_choose = MK_BUT0;
-    eve_cmd_choose->set_image(*MK_IMG(Gtk::Stock::OPEN, Gtk::ICON_SIZE_MENU));
+    eve_cmd_choose->set_image_from_icon_name("document-open", Gtk::ICON_SIZE_MENU);
 
     eve_cmd_choose->signal_clicked().connect(sigc::bind(sigc::mem_fun
         (*this, &GuiConfiguration::select_launcher_file), eve_cmd_entry));
@@ -106,7 +106,7 @@ GuiConfiguration::GuiConfiguration (void)
     launch_table->attach(*eve_cmd_choose, 2, 3, i, i + 1, Gtk::FILL);
   }
 
-  Gtk::VBox* page_launch = MK_VBOX;
+  Gtk::Box* page_launch = MK_VBOX(5);
   page_launch->set_border_width(5);
   page_launch->pack_start(*launch_info_label, false, false, 0);
   page_launch->pack_start(*launch_table, false, false, 0);
@@ -118,7 +118,7 @@ GuiConfiguration::GuiConfiguration (void)
       "You can optionally use a proxy server that is used for both "
       "HTTP and HTTPS connections. "
       "Note that the server monitor doesn't use the proxy.");
-  net_info_label->set_alignment(Gtk::ALIGN_LEFT);
+  net_info_label->set_halign(Gtk::ALIGN_START);
   net_info_label->set_line_wrap(true);
 
   GtkConfCheckButton* use_api_ssl_cb = Gtk::manage(new GtkConfCheckButton
@@ -133,13 +133,13 @@ GuiConfiguration::GuiConfiguration (void)
       ("network.proxy_port"));
   proxy_port_entry->set_width_chars(5);
 
-  Gtk::HBox* net_proxy_entry_box = MK_HBOX;
+  Gtk::Box* net_proxy_entry_box = MK_HBOX(5);
   net_proxy_entry_box->pack_start(*net_proxy_label, false, false, 0);
   net_proxy_entry_box->pack_start(*proxy_entry, true, true, 0);
   net_proxy_entry_box->pack_start(*net_proxy_port_label, false, false, 0);
   net_proxy_entry_box->pack_start(*proxy_port_entry, false, false, 0);
 
-  Gtk::VBox* page_network = MK_VBOX;
+  Gtk::Box* page_network = MK_VBOX(5);
   page_network->set_border_width(5);
   page_network->pack_start(*net_info_label, false, false, 0);
   page_network->pack_start(*use_api_ssl_cb, false, false, 0);
@@ -149,7 +149,7 @@ GuiConfiguration::GuiConfiguration (void)
   /* The NOTIFICATIONS notebook tab. */
   Gtk::Label* notify_info_label = MK_LABEL("Specify how you want "
       "GtkEveMon to notify you if the skill training is complete.");
-  notify_info_label->set_alignment(Gtk::ALIGN_LEFT);
+  notify_info_label->set_halign(Gtk::ALIGN_START);
   notify_info_label->set_line_wrap(true);
 
   GtkConfCheckButton* notify_with_popup = Gtk::manage
@@ -162,14 +162,14 @@ GuiConfiguration::GuiConfiguration (void)
       (new GtkConfCheckButton("Show information bar (in GtkEveMon)", false,
       "notifications.show_info_bar"));
 
-  Gtk::VBox* notify_cb_box = MK_VBOX0;
+  Gtk::Box* notify_cb_box = MK_VBOX(0);
   notify_cb_box->pack_start(*notify_with_popup, false, false, 0);
   notify_cb_box->pack_start(*notify_with_tray, false, false, 0);
   notify_cb_box->pack_start(*notify_with_info_bar, false, false, 0);
 
   Gtk::Label* notify_info2_label = MK_LABEL("See the forums for "
       "how to send emails with this handler.");
-  notify_info2_label->set_alignment(Gtk::ALIGN_LEFT);
+  notify_info2_label->set_halign(Gtk::ALIGN_START);
   notify_info2_label->set_line_wrap(true);
 
   GtkConfCheckButton* notify_handler_enabled = Gtk::manage
@@ -183,11 +183,11 @@ GuiConfiguration::GuiConfiguration (void)
       (new GtkConfTextEntry("notifications.minimum_sp"));
 
   Gtk::Label* notify_command_label = MK_LABEL("Command to execute:");
-  notify_command_label->set_alignment(Gtk::ALIGN_LEFT);
+  notify_command_label->set_halign(Gtk::ALIGN_START);
   Gtk::Label* notify_data_label = MK_LABEL("Data to send (stdin):");
-  notify_data_label->set_alignment(Gtk::ALIGN_LEFT);
+  notify_data_label->set_halign(Gtk::ALIGN_START);
   Gtk::Label* notify_minsp_label = MK_LABEL("Minimum skill SP:");
-  notify_minsp_label->set_alignment(Gtk::ALIGN_LEFT);
+  notify_minsp_label->set_halign(Gtk::ALIGN_START);
 
   Gtk::Table* notify_handler_table = Gtk::manage(new Gtk::Table(4, 2));
   notify_handler_table->set_row_spacings(1);
@@ -207,7 +207,7 @@ GuiConfiguration::GuiConfiguration (void)
   notify_handler_table->attach(*notify_min_sp_entry, 1, 2, 3, 4,
       Gtk::EXPAND | Gtk::FILL);
 
-  Gtk::VBox* page_notifications = MK_VBOX;
+  Gtk::Box* page_notifications = MK_VBOX(5);
   page_notifications->set_border_width(5);
   page_notifications->pack_start(*notify_info_label, false, false, 0);
   page_notifications->pack_start(*notify_cb_box, false, false, 0);
@@ -217,12 +217,12 @@ GuiConfiguration::GuiConfiguration (void)
   /* The TIME_FORMAT notebook tab. */
   Gtk::Label* time_info_label = MK_LABEL
       ("Enter your desired time format here.");
-  time_info_label->set_alignment(Gtk::ALIGN_LEFT);
+  time_info_label->set_halign(Gtk::ALIGN_START);
   time_info_label->set_line_wrap(true);
 
   Gtk::Label* time_info_label2 = MK_LABEL
       ("The default time format is: %Y-%m-%d %H:%M:%S");
-  time_info_label2->set_alignment(Gtk::ALIGN_LEFT);
+  time_info_label2->set_halign(Gtk::ALIGN_START);
   time_info_label2->set_selectable(true);
 
   GtkConfTextEntry* time_format_entry = Gtk::manage
@@ -230,7 +230,7 @@ GuiConfiguration::GuiConfiguration (void)
 
   Gtk::Label* time_info_label3 = MK_LABEL
       ("The default short time format is: %m-%d %H:%M");
-  time_info_label3->set_alignment(Gtk::ALIGN_LEFT);
+  time_info_label3->set_halign(Gtk::ALIGN_START);
   time_info_label3->set_selectable(true);
 
   GtkConfTextEntry* time_short_format_entry = Gtk::manage
@@ -484,11 +484,11 @@ GuiConfiguration::GuiConfiguration (void)
   time_scwin->set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS);
   time_scwin->add(*time_helptext);
 
-  Gtk::HBox* time_example_hbox = MK_HBOX;
+  Gtk::Box* time_example_hbox = MK_HBOX(5);
   time_example_hbox->pack_start(*MK_LABEL("Example:"), false, false, 0);
   time_example_hbox->pack_start(this->time_example, false, false, 0);
 
-  Gtk::VBox* page_timeformat = MK_VBOX;
+  Gtk::Box* page_timeformat = MK_VBOX(5);
   page_timeformat->set_border_width(5);
   page_timeformat->pack_start(*time_info_label, false, false, 0);
   page_timeformat->pack_start(*time_info_label2, false, false, 0);
@@ -501,8 +501,8 @@ GuiConfiguration::GuiConfiguration (void)
   this->update_time_example();
 
   /* Button bar. */
-  Gtk::HBox* button_bar = MK_HBOX;
-  Gtk::Button* close_but = MK_BUT(Gtk::Stock::CLOSE);
+  Gtk::Box* button_bar = MK_HBOX(5);
+  Gtk::Button* close_but = MK_BUT("Close");
   button_bar->pack_end(*close_but, false, false, 0);
   //button_bar->pack_start(*MK_HSEP, true, true, 0);
 
@@ -518,11 +518,11 @@ GuiConfiguration::GuiConfiguration (void)
   image_frame->set_shadow_type(Gtk::SHADOW_IN);
   image_frame->add(*Gtk::manage(new Gtk::Image(ImageStore::aboutlogo)));
 
-  Gtk::HBox* main_hbox = MK_HBOX;
+  Gtk::Box* main_hbox = MK_HBOX(5);
   main_hbox->pack_start(*image_frame, false, false, 0);
   main_hbox->pack_start(*notebook, true, true, 0);
 
-  Gtk::VBox* main_vbox = MK_VBOX;
+  Gtk::Box* main_vbox = MK_VBOX(5);
   main_vbox->set_border_width(5);
   main_vbox->pack_start(*main_hbox, true, true, 0);
   main_vbox->pack_end(*button_bar, false, false, 0);
@@ -570,8 +570,8 @@ GuiConfiguration::select_launcher_file (Gtk::Entry* cmd_entry)
 {
   Gtk::FileChooserDialog fcd(*this, "Select file to execute...",
       Gtk::FILE_CHOOSER_ACTION_OPEN);
-  fcd.add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-  fcd.add_button(Gtk::Stock::SAVE, Gtk::RESPONSE_OK);
+  fcd.add_button("Cancel", Gtk::RESPONSE_CANCEL);
+  fcd.add_button("Save", Gtk::RESPONSE_OK);
 
   int ret = fcd.run();
   if (ret == Gtk::RESPONSE_OK)

--- a/src/gui/guiconfiguration.h
+++ b/src/gui/guiconfiguration.h
@@ -1,20 +1,17 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GUI_OPTIONS_HEADER
 #define GUI_OPTIONS_HEADER
 
-#include <gtkmm/label.h>
-#include <gtkmm/entry.h>
+#include <gtkmm.h>
 
 #include "winbase.h"
 #include "gtkconfwidgets.h"

--- a/src/gui/guievelauncher.cc
+++ b/src/gui/guievelauncher.cc
@@ -1,15 +1,16 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <iostream>
 
-#include <gtkmm/table.h>
-#include <gtkmm/label.h>
-#include <gtkmm/entry.h>
-#include <gtkmm/separator.h>
-#include <gtkmm/box.h>
-#include <gtkmm/stock.h>
-#include <gtkmm/button.h>
-#include <gtkmm/image.h>
-#include <gtkmm/frame.h>
-#include <gtkmm/messagedialog.h>
+#include <gtkmm.h>
 
 #include "util/exception.h"
 #include "util/helpers.h"
@@ -69,7 +70,7 @@ GuiEveLauncher::GuiEveLauncher (std::vector<std::string> const& cmds)
     eve_cmd_entry->set_text(cmds[i]);
     eve_cmd_entry->set_editable(false);
     Gtk::Button* launch_but = MK_BUT0;
-    launch_but->set_image(*MK_IMG(Gtk::Stock::EXECUTE, Gtk::ICON_SIZE_MENU));
+    launch_but->set_image_from_icon_name("system-run", Gtk::ICON_SIZE_MENU);
     launch_but->signal_clicked().connect(sigc::bind(sigc::mem_fun
         (*this, &GuiEveLauncher::run_command), cmds[i]));
 
@@ -84,12 +85,12 @@ GuiEveLauncher::GuiEveLauncher (std::vector<std::string> const& cmds)
   main_frame->add(*launch_table);
 
   /* Button bar. */
-  Gtk::HBox* button_bar = MK_HBOX;
-  Gtk::Button* close_but = MK_BUT(Gtk::Stock::CLOSE);
+  Gtk::Box* button_bar = MK_HBOX(5);
+  Gtk::Button* close_but = MK_BUT("Close");
   button_bar->pack_start(*MK_HSEP, true, true, 0);
   button_bar->pack_end(*close_but, false, false, 0);
 
-  Gtk::VBox* main_box = MK_VBOX;
+  Gtk::Box* main_box = MK_VBOX(5);
   main_box->set_border_width(5);
   main_box->pack_start(*main_frame, false, false, 0);
   main_box->pack_end(*button_bar, false, false, 0);

--- a/src/gui/guievelauncher.h
+++ b/src/gui/guievelauncher.h
@@ -1,14 +1,12 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GUI_EVE_LAUNCHER
 #define GUI_EVE_LAUNCHER

--- a/src/gui/guiplanattribopt.cc
+++ b/src/gui/guiplanattribopt.cc
@@ -1,7 +1,14 @@
-#include <gtkmm/stock.h>
-#include <gtkmm/scrolledwindow.h>
-#include <gtkmm/separator.h>
-#include <gtkmm/table.h>
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
+#include <gtkmm.h>
 
 #include "util/helpers.h"
 #include "api/evetime.h"
@@ -43,13 +50,13 @@ GuiPlanAttribOpt::GuiPlanAttribOpt (void)
   this->notebook.append_page(*breakdown_page, "Plan breakdown");
 
   /* Button bar. */
-  Gtk::Button* close_but = MK_BUT(Gtk::Stock::CLOSE);
-  Gtk::HBox* button_box = MK_HBOX;
+  Gtk::Button* close_but = MK_BUT("Close");
+  Gtk::Box* button_box = MK_HBOX(5);
   button_box->pack_start(*MK_HSEP, true, true, 0);
   button_box->pack_end(*close_but, false, false, 0);
 
   /* Main box. */
-  Gtk::VBox* mainbox = MK_VBOX;
+  Gtk::Box* mainbox = MK_VBOX(5);
   mainbox->pack_start(this->notebook, true, true, 0);
   mainbox->pack_end(*button_box, false, false, 0);
   mainbox->set_border_width(5);
@@ -70,17 +77,17 @@ Gtk::Widget*
 GuiPlanAttribOpt::create_config_page (void)
 {
   /* Some information on usage of the configuration. */
-  Gtk::Image* info_image = MK_IMG(Gtk::Stock::DIALOG_QUESTION,
-      Gtk::ICON_SIZE_DIALOG);
+  Gtk::Image* info_image = MK_IMG0;
+  info_image->set_from_icon_name("dialog-question", Gtk::ICON_SIZE_DIALOG);
   Gtk::Label* info_label = MK_LABEL("Do you want to optimize the whole plan?\n"
       "Please select whether you want to optimize\n"
       "the whole skill plan or just a part of it.");
   info_label->set_line_wrap(true);
   info_label->set_justify(Gtk::JUSTIFY_LEFT);
-  info_label->set_alignment(Gtk::ALIGN_LEFT);
+  info_label->set_halign(Gtk::ALIGN_START);
   //info_label->set_width_chars(50);
 
-  Gtk::HBox* info_box = MK_HBOX;
+  Gtk::Box* info_box = MK_HBOX(5);
   info_box->set_spacing(10);
   info_box->pack_start(*info_image, false, false, 0);
   info_box->pack_start(*info_label, true, true, 0);
@@ -94,23 +101,23 @@ GuiPlanAttribOpt::create_config_page (void)
   this->set_selection_sensitivity(false);
 
   /* Create a table and add the widgets to it. */
-  Gtk::VBox* dialog_vbox = MK_VBOX;
+  Gtk::Box* dialog_vbox = MK_VBOX(5);
   dialog_vbox->pack_start(this->rb_whole_plan, false, false, 0);
   dialog_vbox->pack_start(this->rb_partial_plan, false, false, 0);
   dialog_vbox->pack_start(this->skill_selection, false, false, 0);
 
   /* Create the button for the next page. */
   Gtk::Button* calculate_but = MK_BUT0;
-  calculate_but->set_image(*MK_IMG(Gtk::Stock::MEDIA_PLAY,
-      Gtk::ICON_SIZE_BUTTON));
+  calculate_but->set_image_from_icon_name("media-playback-start",
+      Gtk::ICON_SIZE_BUTTON);
   calculate_but->set_label("Optimize attributes");
 
   /* The button box. */
-  Gtk::HBox* button_box = MK_HBOX;
+  Gtk::Box* button_box = MK_HBOX(5);
   button_box->pack_end(*calculate_but, false, false, 0);
 
   /* The main box. */
-  Gtk::VBox* main_box = MK_VBOX;
+  Gtk::Box* main_box = MK_VBOX(5);
   main_box->set_border_width(5);
   main_box->pack_start(*info_box, false, false, 0);
   main_box->pack_start(*MK_HSEP, false, false, 0);
@@ -146,7 +153,8 @@ GuiPlanAttribOpt::create_attrib_page (void)
   Gtk::Label* difference_time_name_label = MK_LABEL("Improvement:");
 
   /* Create info and warning box. */
-  Gtk::Image* info_image = MK_IMG(Gtk::Stock::DIALOG_INFO,
+  Gtk::Image* info_image = MK_IMG0;
+  info_image->set_from_icon_name("dialog-information",
       Gtk::ICON_SIZE_DIALOG);
   Gtk::Label* information_label = MK_LABEL("Below you find the attribute "
       "point distribution which will reduce the current plan's training time "
@@ -154,21 +162,21 @@ GuiPlanAttribOpt::create_attrib_page (void)
       "Note: You can only remap your attributes once a year!");
   information_label->set_line_wrap(true);
   information_label->set_justify(Gtk::JUSTIFY_LEFT);
-  information_label->set_alignment(Gtk::ALIGN_LEFT);
+  information_label->set_halign(Gtk::ALIGN_START);
 
-  Gtk::HBox* info_box = MK_HBOX;
+  Gtk::Box* info_box = MK_HBOX(5);
   info_box->set_spacing(10);
   info_box->pack_start(*info_image, false, false, 0);
   info_box->pack_start(*information_label, true, true, 0);
 
-  Gtk::Image* warning_image = MK_IMG(Gtk::Stock::DIALOG_WARNING,
-      Gtk::ICON_SIZE_DIALOG);
+  Gtk::Image* warning_image = MK_IMG0;
+  warning_image->set_from_icon_name("dialog-warning", Gtk::ICON_SIZE_DIALOG);
   Gtk::Label* warning_label = MK_LABEL("The optimized plan's training time "
       "is below one year!\nPlease note that you're allowed to remap your "
       "attributes only once a year.");
   warning_label->set_line_wrap(true);
   warning_label->set_justify(Gtk::JUSTIFY_LEFT);
-  warning_label->set_alignment(Gtk::ALIGN_LEFT);
+  warning_label->set_halign(Gtk::ALIGN_START);
 
   warning_label->show();
   warning_image->show();
@@ -178,38 +186,38 @@ GuiPlanAttribOpt::create_attrib_page (void)
   this->warning_box.set_no_show_all(true);
 
   /* Set the alignments for all the attributes' labels. */
-  cha_name_label->set_alignment(Gtk::ALIGN_LEFT);
-  intl_name_label->set_alignment(Gtk::ALIGN_LEFT);
-  per_name_label->set_alignment(Gtk::ALIGN_LEFT);
-  mem_name_label->set_alignment(Gtk::ALIGN_LEFT);
-  wil_name_label->set_alignment(Gtk::ALIGN_LEFT);
+  cha_name_label->set_halign(Gtk::ALIGN_START);
+  intl_name_label->set_halign(Gtk::ALIGN_START);
+  per_name_label->set_halign(Gtk::ALIGN_START);
+  mem_name_label->set_halign(Gtk::ALIGN_START);
+  wil_name_label->set_halign(Gtk::ALIGN_START);
 
-  this->base_cha_label.set_alignment(Gtk::ALIGN_RIGHT);
-  this->base_intl_label.set_alignment(Gtk::ALIGN_RIGHT);
-  this->base_per_label.set_alignment(Gtk::ALIGN_RIGHT);
-  this->base_mem_label.set_alignment(Gtk::ALIGN_RIGHT);
-  this->base_wil_label.set_alignment(Gtk::ALIGN_RIGHT);
+  this->base_cha_label.set_halign(Gtk::ALIGN_END);
+  this->base_intl_label.set_halign(Gtk::ALIGN_END);
+  this->base_per_label.set_halign(Gtk::ALIGN_END);
+  this->base_mem_label.set_halign(Gtk::ALIGN_END);
+  this->base_wil_label.set_halign(Gtk::ALIGN_END);
 
-  this->total_cha_label.set_alignment(Gtk::ALIGN_RIGHT);
-  this->total_intl_label.set_alignment(Gtk::ALIGN_RIGHT);
-  this->total_per_label.set_alignment(Gtk::ALIGN_RIGHT);
-  this->total_mem_label.set_alignment(Gtk::ALIGN_RIGHT);
-  this->total_wil_label.set_alignment(Gtk::ALIGN_RIGHT);
+  this->total_cha_label.set_halign(Gtk::ALIGN_END);
+  this->total_intl_label.set_halign(Gtk::ALIGN_END);
+  this->total_per_label.set_halign(Gtk::ALIGN_END);
+  this->total_mem_label.set_halign(Gtk::ALIGN_END);
+  this->total_wil_label.set_halign(Gtk::ALIGN_END);
 
   /* Set the alignments for all the times' labels. */
-  best_time_name_label->set_alignment(Gtk::ALIGN_LEFT);
-  original_time_name_label->set_alignment(Gtk::ALIGN_LEFT);
-  difference_time_name_label->set_alignment(Gtk::ALIGN_LEFT);
+  best_time_name_label->set_halign(Gtk::ALIGN_START);
+  original_time_name_label->set_halign(Gtk::ALIGN_START);
+  difference_time_name_label->set_halign(Gtk::ALIGN_START);
 
-  this->best_time_label.set_alignment(Gtk::ALIGN_RIGHT);
-  this->original_time_label.set_alignment(Gtk::ALIGN_RIGHT);
-  this->difference_time_label.set_alignment(Gtk::ALIGN_RIGHT);
+  this->best_time_label.set_halign(Gtk::ALIGN_END);
+  this->original_time_label.set_halign(Gtk::ALIGN_END);
+  this->difference_time_label.set_halign(Gtk::ALIGN_END);
 
   /* Configure the table and add fill it with content. */
   Gtk::Label* base_attr_label = MK_LABEL("Base");
-  base_attr_label->set_alignment(Gtk::ALIGN_RIGHT);
+  base_attr_label->set_halign(Gtk::ALIGN_END);
   Gtk::Label* total_attr_label = MK_LABEL("Total");
-  total_attr_label->set_alignment(Gtk::ALIGN_RIGHT);
+  total_attr_label->set_halign(Gtk::ALIGN_END);
 
   Gtk::Table* attribute_table = MK_TABLE(9, 3);
   attribute_table->set_col_spacings(10);
@@ -242,15 +250,15 @@ GuiPlanAttribOpt::create_attrib_page (void)
 
   /* Configure some buttons. */
   Gtk::Button* view_plan_but = MK_BUT0;
-  view_plan_but->set_image(*MK_IMG(Gtk::Stock::MEDIA_PLAY,
-      Gtk::ICON_SIZE_BUTTON));
+  view_plan_but->set_image_from_icon_name("media-playback-start",
+      Gtk::ICON_SIZE_BUTTON);
   view_plan_but->set_label("View plan breakdown");
 
-  Gtk::HBox* view_plan_box = MK_HBOX;
+  Gtk::Box* view_plan_box = MK_HBOX(5);
   view_plan_box->pack_end(*view_plan_but, false, false, 0);
 
   /* Assemble and configure the widgets. */
-  Gtk::VBox* attribute_box = MK_VBOX;
+  Gtk::Box* attribute_box = MK_VBOX(5);
   attribute_box->set_border_width(5);
   attribute_box->pack_start(*info_box, false, false);
   attribute_box->pack_start(*MK_HSEP, false, false, 0);
@@ -297,7 +305,7 @@ GuiPlanAttribOpt::set_plan (GtkSkillList const& plan)
     GtkSkillInfo& info = this->plan[i];
     Glib::ustring skillname = info.skill->name;
     skillname += " " + Helpers::get_roman_from_int(info.plan_level);
-    this->skill_selection.append_text(skillname);
+    this->skill_selection.append(skillname);
   }
   this->skill_selection.set_active(0);
 }

--- a/src/gui/guiplanattribopt.h
+++ b/src/gui/guiplanattribopt.h
@@ -1,24 +1,17 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GUI_PLAN_ATTRIB_OPT_HEADER
 #define	GUI_PLAN_ATTRIB_OPT_HEADER
 
-#include <gtkmm/notebook.h>
-#include <gtkmm/label.h>
-#include <gtkmm/treeview.h>
-#include <gtkmm/liststore.h>
-#include <gtkmm/radiobutton.h>
-#include <gtkmm/comboboxtext.h>
+#include <gtkmm.h>
 
 #include "winbase.h"
 #include "gtktrainingplan.h"
@@ -75,7 +68,7 @@ class GuiPlanAttribOpt : public WinBase
     Gtk::Label original_time_label;
     Gtk::Label best_time_label;
     Gtk::Label difference_time_label;
-    Gtk::HBox warning_box;
+    Gtk::Box warning_box;
 
     GtkTreeModelColumnsOptimizer cols;
     Glib::RefPtr<Gtk::ListStore> liststore;
@@ -97,4 +90,3 @@ class GuiPlanAttribOpt : public WinBase
 };
 
 #endif	/* GUI_PLAN_ATTRIB_OPT_HEADER */
-

--- a/src/gui/guiskill.cc
+++ b/src/gui/guiskill.cc
@@ -1,11 +1,14 @@
-#include <gtkmm/stock.h>
-#include <gtkmm/button.h>
-#include <gtkmm/separator.h>
-#include <gtkmm/box.h>
-#include <gtkmm/label.h>
-#include <gtkmm/table.h>
-#include <gtkmm/scrolledwindow.h>
-#include <gtkmm/frame.h>
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
+#include <gtkmm.h>
 
 #include "util/helpers.h"
 #include "api/apiskilltree.h"
@@ -18,20 +21,20 @@ GuiSkill::GuiSkill (void)
   this->skill_desc.set_wrap_mode(Gtk::WRAP_WORD);
   this->skill_desc.set_editable(false);
   this->skill_name.set_selectable(true);
-  this->skill_name.set_alignment(Gtk::ALIGN_LEFT);
+  this->skill_name.set_halign(Gtk::ALIGN_START);
   this->group_name.set_selectable(true);
-  this->group_name.set_alignment(Gtk::ALIGN_LEFT);
+  this->group_name.set_halign(Gtk::ALIGN_START);
   this->skill_attribs.set_selectable(true);
-  this->skill_attribs.set_alignment(Gtk::ALIGN_LEFT);
-  this->skill_id.set_alignment(Gtk::ALIGN_RIGHT);
-  this->group_id.set_alignment(Gtk::ALIGN_RIGHT);
+  this->skill_attribs.set_halign(Gtk::ALIGN_START);
+  this->skill_id.set_halign(Gtk::ALIGN_END);
+  this->group_id.set_halign(Gtk::ALIGN_END);
 
   Gtk::Label* skill_name_desc = MK_LABEL("Skill name:");
   Gtk::Label* group_name_desc = MK_LABEL("Skill group:");
   Gtk::Label* skill_attribs_desc = MK_LABEL("Attributes:");
-  skill_name_desc->set_alignment(Gtk::ALIGN_LEFT);
-  group_name_desc->set_alignment(Gtk::ALIGN_LEFT);
-  skill_attribs_desc->set_alignment(Gtk::ALIGN_LEFT);
+  skill_name_desc->set_halign(Gtk::ALIGN_START);
+  group_name_desc->set_halign(Gtk::ALIGN_START);
+  skill_attribs_desc->set_halign(Gtk::ALIGN_START);
 
   Gtk::Table* info_table = MK_TABLE(3, 3);
   info_table->set_col_spacings(5);
@@ -48,7 +51,7 @@ GuiSkill::GuiSkill (void)
   info_table->attach(this->skill_id, 2, 3, 0, 1, Gtk::FILL);
   info_table->attach(this->group_id, 2, 3, 1, 2, Gtk::FILL);
 
-  Gtk::HBox* desc_separator = MK_HBOX;
+  Gtk::Box* desc_separator = MK_HBOX(5);
   desc_separator->pack_start(*MK_HSEP, true, true, 0);
   desc_separator->pack_start(*MK_LABEL("Description"), false, false, 0);
   desc_separator->pack_start(*MK_HSEP, true, true, 0);
@@ -58,7 +61,7 @@ GuiSkill::GuiSkill (void)
   desc_scwin->set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS);
   desc_scwin->add(this->skill_desc);
 
-  Gtk::VBox* skill_vbox = MK_VBOX;
+  Gtk::Box* skill_vbox = MK_VBOX(5);
   skill_vbox->set_border_width(5);
   skill_vbox->pack_start(*info_table, false, false, 0);
   skill_vbox->pack_start(*desc_separator, false, false, 0);
@@ -68,12 +71,13 @@ GuiSkill::GuiSkill (void)
   info_frame->set_shadow_type(Gtk::SHADOW_OUT);
   info_frame->add(*skill_vbox);
 
-  Gtk::Button* close_but = MK_BUT(Gtk::Stock::CLOSE);
-  Gtk::HBox* button_box = MK_HBOX;
+  Gtk::Button* close_but = MK_BUT0;
+  close_but->set_image_from_icon_name("window-close", Gtk::ICON_SIZE_BUTTON);
+  Gtk::Box* button_box = MK_HBOX(5);
   button_box->pack_start(*MK_HSEP, true, true, 0);
   button_box->pack_start(*close_but, false, false, 0);
 
-  Gtk::VBox* main_vbox = MK_VBOX;
+  Gtk::Box* main_vbox = MK_VBOX(5);
   main_vbox->set_border_width(5);
   main_vbox->pack_start(*info_frame, true, true, 0);
   main_vbox->pack_end(*button_box, false, false, 0);

--- a/src/gui/guiskill.h
+++ b/src/gui/guiskill.h
@@ -13,9 +13,7 @@
 #ifndef GUI_SKILL_HEADER
 #define GUI_SKILL_HEADER
 
-#include <gtkmm/label.h>
-#include <gtkmm/textbuffer.h>
-#include <gtkmm/textview.h>
+#include <gtkmm.h>
 
 #include "winbase.h"
 

--- a/src/gui/guiskillplanner.cc
+++ b/src/gui/guiskillplanner.cc
@@ -1,13 +1,16 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <iostream>
-#include <gtkmm/table.h>
-#include <gtkmm/main.h>
-#include <gtkmm/box.h>
-#include <gtkmm/label.h>
-#include <gtkmm/stock.h>
-#include <gtkmm/image.h>
-#include <gtkmm/paned.h>
-#include <gtkmm/separator.h>
-#include <gtkmm/scrolledwindow.h>
+
+#include <gtkmm.h>
 
 #include "util/helpers.h"
 #include "bits/config.h"
@@ -28,19 +31,19 @@ GuiSkillPlanner::GuiSkillPlanner (void)
   this->details_nb.append_page(this->plan_gui, "Training plan");
   this->details_nb.append_page(this->details_gui, "Item details");
 
-  Gtk::Button* close_but = MK_BUT(Gtk::Stock::CLOSE);
-  Gtk::HBox* button_hbox = MK_HBOX;
+  Gtk::Button* close_but = MK_BUT("Close");
+  Gtk::Box* button_hbox = MK_HBOX(5);
   button_hbox->pack_start(*MK_HSEP, true, true, 0);
   button_hbox->pack_start(*close_but, false, false, 0);
 
-  Gtk::VBox* details_panechild = MK_VBOX;
+  Gtk::Box* details_panechild = MK_VBOX(5);
   details_panechild->pack_start(this->details_nb, true, true, 0);
   details_panechild->pack_start(*button_hbox, false, false, 0);
 
   this->main_pane.add1(this->browser_nb);
   this->main_pane.add2(*details_panechild);
 
-  Gtk::VBox* main_vbox = MK_VBOX;
+  Gtk::Box* main_vbox = MK_VBOX(5);
   main_vbox->set_border_width(5);
   main_vbox->pack_start(this->main_pane, true, true, 0);
 
@@ -63,8 +66,6 @@ GuiSkillPlanner::GuiSkillPlanner (void)
       (*this, &GuiSkillPlanner::on_element_activated));
   this->details_gui.signal_planning_requested().connect(sigc::mem_fun
       (*this, &GuiSkillPlanner::on_planning_requested));
-  Gtk::Main::signal_quit().connect(sigc::mem_fun
-      (*this, &GuiSkillPlanner::on_gtkmain_quit));
 
   this->add(*main_vbox);
   this->set_title("Skill browser - GtkEveMon");
@@ -157,13 +158,4 @@ GuiSkillPlanner::on_planning_requested (ApiElement const* elem, int level)
 {
   this->details_nb.set_current_page(0);
   this->plan_gui.append_element(elem, level);
-}
-
-/* ---------------------------------------------------------------- */
-
-bool
-GuiSkillPlanner::on_gtkmain_quit (void)
-{
-  this->close();
-  return false;
 }

--- a/src/gui/guiskillplanner.h
+++ b/src/gui/guiskillplanner.h
@@ -1,20 +1,17 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GUI_SKILL_PLANNER_HEADER
 #define GUI_SKILL_PLANNER_HEADER
 
-#include <gtkmm/paned.h>
-#include <gtkmm/notebook.h>
+#include <gtkmm.h>
 
 #include "bits/character.h"
 #include "winbase.h"
@@ -44,8 +41,6 @@ class GuiSkillPlanner : public WinBase
 
     void init_from_config (void);
     void store_to_config (void);
-
-    bool on_gtkmain_quit (void);
 
   public:
     GuiSkillPlanner (void);

--- a/src/gui/guiskillqueue.cc
+++ b/src/gui/guiskillqueue.cc
@@ -1,8 +1,14 @@
-#include <gtkmm/button.h>
-#include <gtkmm/box.h>
-#include <gtkmm/separator.h>
-#include <gtkmm/frame.h>
-#include <gtkmm/stock.h>
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
+#include <gtkmm.h>
 
 #include "gtkdefines.h"
 #include "guiskillqueue.h"
@@ -12,13 +18,14 @@ GuiSkillQueue::GuiSkillQueue (CharacterPtr character)
   Gtk::Frame* main_frame = MK_FRAME0;
   main_frame->add(this->queue);
 
-  Gtk::Button* close_but = MK_BUT(Gtk::Stock::CLOSE);
+  Gtk::Button* close_but = MK_BUT0;
+  close_but->set_image_from_icon_name("window-close", Gtk::ICON_SIZE_BUTTON);
 
-  Gtk::HBox* button_box = MK_HBOX;
+  Gtk::Box* button_box = MK_HBOX(5);
   button_box->pack_start(*MK_HSEP, true, true, 0);
   button_box->pack_start(*close_but, false, false, 0);
 
-  Gtk::VBox* main_box = MK_VBOX;
+  Gtk::Box* main_box = MK_VBOX(5);
   main_box->set_border_width(5);
   main_box->pack_start(*main_frame, true, true, 0);
   main_box->pack_start(*button_box, false, false, 0);

--- a/src/gui/guiskillqueue.h
+++ b/src/gui/guiskillqueue.h
@@ -1,14 +1,12 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GUI_SKILL_QUEUE_HEADER
 #define GUI_SKILL_QUEUE_HEADER

--- a/src/gui/guiupdater.h
+++ b/src/gui/guiupdater.h
@@ -1,20 +1,17 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GUI_UPDATER_HEADER
 #define GUI_UPDATER_HEADER
 
-#include <gtkmm/button.h>
-#include <gtkmm/box.h>
+#include <gtkmm.h>
 
 #include "bits/updater.h"
 #include "net/asynchttp.h"
@@ -31,7 +28,8 @@ class GuiUpdater : public WinBase, public UpdaterBase
     GtkDownloader downloader;
     Gtk::Button* close_but;
     Gtk::Button* update_but;
-    Gtk::VBox files_box;
+    Gtk::Box* frame_box;
+    Gtk::Box* files_box;
 
   protected:
     void rebuild_files_box (void);

--- a/src/gui/guiuserdata.cc
+++ b/src/gui/guiuserdata.cc
@@ -1,14 +1,16 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <iostream>
-#include <gtkmm/label.h>
-#include <gtkmm/table.h>
-#include <gtkmm/box.h>
-#include <gtkmm/separator.h>
-#include <gtkmm/scrolledwindow.h>
-#include <gtkmm/image.h>
-#include <gtkmm/button.h>
-#include <gtkmm/stock.h>
-#include <gtkmm/frame.h>
-#include <gtkmm/messagedialog.h>
+
+#include <gtkmm.h>
 
 #include "util/exception.h"
 #include "api/apicharlist.h"
@@ -19,7 +21,7 @@
 #include "guiuserdata.h"
 
 GuiUserData::GuiUserData (void)
-  : apply_button(Gtk::Stock::APPLY)
+  : apply_button("Apply")
 {
   /* Setup the EVE API fetcher. */
   this->charlist_fetcher.set_doctype(API_DOCTYPE_CHARLIST);
@@ -41,13 +43,15 @@ GuiUserData::GuiUserData (void)
 
   /* Build GUI. */
   Gtk::Label* history_label = MK_LABEL("API Keys:");
-  Gtk::HBox* history_hbox = MK_HBOX;
+  Gtk::Box* history_hbox = MK_HBOX(5);
   history_hbox->pack_start(*history_label, false, false, 0);
   history_hbox->pack_start(this->history_box, true, true, 0);
 
-  Gtk::HBox* info1_hbox = Gtk::manage(new Gtk::HBox(false, 10));
-  info1_hbox->pack_start(*Gtk::manage(new Gtk::Image
-      (Gtk::Stock::DIALOG_INFO, Gtk::ICON_SIZE_DIALOG)), false, false, 0);
+  Gtk::Box* info1_hbox = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 10));
+  Gtk::Image* info1_image = MK_IMG0;
+  info1_image->set_from_icon_name("dialog-information",
+      Gtk::ICON_SIZE_DIALOG);
+  info1_hbox->pack_start(*info1_image, false, false, 0);
 
   Gtk::Label* info1_label = MK_LABEL(
       "Enter your key ID and your verification code such that GtkEveMon "
@@ -55,11 +59,11 @@ GuiUserData::GuiUserData (void)
       "You can get the information at:");
   info1_label->set_width_chars(50);
   info1_label->set_line_wrap(true);
-  info1_label->set_alignment(Gtk::ALIGN_LEFT);
+  info1_label->set_halign(Gtk::ALIGN_START);
   Gtk::Label* info1b_label = MK_LABEL("http://support.eveonline.com/api");
-  info1b_label->set_alignment(Gtk::ALIGN_LEFT);
+  info1b_label->set_halign(Gtk::ALIGN_START);
   info1b_label->set_selectable(true);
-  Gtk::VBox* info1_vbox = MK_VBOX0;
+  Gtk::Box* info1_vbox = MK_VBOX(0);
   info1_vbox->pack_start(*info1_label, false, false, 0);
   info1_vbox->pack_start(*info1b_label, false, false, 0);
   info1_hbox->pack_start(*info1_vbox, true, true, 0);
@@ -70,8 +74,8 @@ GuiUserData::GuiUserData (void)
   data_table->set_col_spacings(5);
   Gtk::Label* userid_label = MK_LABEL("Key ID:");
   Gtk::Label* apikey_label = MK_LABEL("V-Code:");
-  userid_label->set_alignment(Gtk::ALIGN_LEFT);
-  apikey_label->set_alignment(Gtk::ALIGN_LEFT);
+  userid_label->set_halign(Gtk::ALIGN_START);
+  apikey_label->set_halign(Gtk::ALIGN_START);
   data_table->attach(*userid_label, 0, 1, 0, 1, Gtk::FILL, Gtk::FILL);
   data_table->attach(*apikey_label, 0, 1, 1, 2, Gtk::FILL, Gtk::FILL);
   data_table->attach(this->userid_entry, 1, 2, 0, 1,
@@ -81,18 +85,20 @@ GuiUserData::GuiUserData (void)
   data_table->attach(this->api_v1_cb, 2, 3, 0, 1,
       Gtk::SHRINK, Gtk::SHRINK);
 
-  Gtk::HBox* apply_separator = MK_HBOX;
+  Gtk::Box* apply_separator = MK_HBOX(5);
   apply_separator->pack_start(*MK_HSEP, true, true, 0);
   apply_separator->pack_start(this->apply_button, false, false, 0);
 
-  Gtk::HBox* info2_hbox = Gtk::manage(new Gtk::HBox(false, 10));
-  info2_hbox->pack_start(*Gtk::manage(new Gtk::Image
-      (Gtk::Stock::DIALOG_INFO, Gtk::ICON_SIZE_DIALOG)), false, false, 0);
+  Gtk::Box* info2_hbox = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 10));
+  Gtk::Image* info2_image = MK_IMG0;
+  info2_image->set_from_icon_name("dialog-information",
+      Gtk::ICON_SIZE_DIALOG);
+  info2_hbox->pack_start(*info2_image, false, false, 0);
   Gtk::Label* info2_label = MK_LABEL(
       "After entering your user information click the button above "
       "to load the character list. Select the characters you want GtkEveMon "
       "to display.");
-  info2_label->set_alignment(Gtk::ALIGN_LEFT);
+  info2_label->set_halign(Gtk::ALIGN_START);
   info2_label->set_line_wrap(true);
   info2_hbox->pack_start(*info2_label, true, true, 0);
 
@@ -101,7 +107,7 @@ GuiUserData::GuiUserData (void)
   scwin->set_shadow_type(Gtk::SHADOW_ETCHED_IN);
   scwin->add(this->char_list);
 
-  Gtk::VBox* settings_vbox = MK_VBOX;
+  Gtk::Box* settings_vbox = MK_VBOX(5);
   settings_vbox->set_border_width(5);
   settings_vbox->pack_start(*history_hbox, false, false, 0);
   settings_vbox->pack_start(*MK_HSEP, false, false, 0);
@@ -115,15 +121,15 @@ GuiUserData::GuiUserData (void)
   main_frame->add(*settings_vbox);
   main_frame->set_shadow_type(Gtk::SHADOW_OUT);
 
-  Gtk::Button* but_close = MK_BUT(Gtk::Stock::CLOSE);
-  Gtk::Button* but_add = MK_BUT(Gtk::Stock::ADD);
+  Gtk::Button* but_close = MK_BUT("Close");
+  Gtk::Button* but_add = MK_BUT("Add");
 
-  Gtk::HBox* button_bar = MK_HBOX;
+  Gtk::Box* button_bar = MK_HBOX(5);
   button_bar->pack_start(*but_close, false, false, 0);
   button_bar->pack_start(*MK_HSEP, true, true, 0);
   button_bar->pack_start(*but_add, false, false, 0);
 
-  Gtk::VBox* main_vbox = MK_VBOX;
+  Gtk::Box* main_vbox = MK_VBOX(5);
   main_vbox->set_border_width(5);
   main_vbox->pack_start(*main_frame, true, true, 0);
   main_vbox->pack_end(*button_bar, false, false, 0);

--- a/src/gui/guiuserdata.h
+++ b/src/gui/guiuserdata.h
@@ -1,23 +1,18 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GUI_USER_DATA_HEADER
 #define GUI_USER_DATA_HEADER
 
 #include <string>
-#include <gtkmm/combobox.h>
-#include <gtkmm/entry.h>
-#include <gtkmm/treeview.h>
-#include <gtkmm/liststore.h>
+#include <gtkmm.h>
 
 #include "api/eveapi.h"
 #include "winbase.h"

--- a/src/gui/guixmlsource.cc
+++ b/src/gui/guixmlsource.cc
@@ -1,22 +1,26 @@
-#include <gtkmm/textbuffer.h>
-#include <gtkmm/textview.h>
-#include <gtkmm/separator.h>
-#include <gtkmm/box.h>
-#include <gtkmm/button.h>
-#include <gtkmm/scrolledwindow.h>
-#include <gtkmm/stock.h>
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
+#include <gtkmm.h>
 
 #include "gtkdefines.h"
 #include "guixmlsource.h"
 
 GuiXmlSource::GuiXmlSource (void)
 {
-  Gtk::Button* close_but = MK_BUT(Gtk::Stock::CLOSE);
-  Gtk::HBox* button_box = MK_HBOX;
+  Gtk::Button* close_but = MK_BUT("Close");
+  Gtk::Box* button_box = MK_HBOX(5);
   button_box->pack_start(*MK_HSEP, true, true, 0);
   button_box->pack_start(*close_but, false, false, 0);
 
-  Gtk::VBox* main_box = MK_VBOX;
+  Gtk::Box* main_box = MK_VBOX(5);
   main_box->set_border_width(5);
   main_box->pack_start(this->notebook, true, true, 0);
   main_box->pack_start(*button_box, false, false, 0);

--- a/src/gui/guixmlsource.h
+++ b/src/gui/guixmlsource.h
@@ -1,20 +1,19 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GUI_XML_SOURCE_HEADER
 #define GUI_XML_SOURCE_HEADER
 
 #include <string>
-#include <gtkmm/notebook.h>
+
+#include <gtkmm.h>
 
 #include "net/http.h"
 #include "winbase.h"

--- a/src/gui/imagestore.cc
+++ b/src/gui/imagestore.cc
@@ -1,3 +1,13 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <cmath>
 
 #include "images/skill.h"

--- a/src/gui/imagestore.h
+++ b/src/gui/imagestore.h
@@ -1,19 +1,17 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef IMAGE_STORE_HEADER
 #define IMAGE_STORE_HEADER
 
-#include <gdkmm/pixbuf.h>
+#include <gdkmm.h>
 
 class ImageStore
 {

--- a/src/gui/maingui.cc
+++ b/src/gui/maingui.cc
@@ -1,12 +1,17 @@
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
+
 #include <iostream>
 #include <sstream>
-#include <gtkmm/button.h>
-#include <gtkmm/main.h>
-#include <gtkmm/frame.h>
-#include <gtkmm/box.h>
-#include <gtkmm/separator.h>
-#include <gtkmm/stock.h>
-#include <gtkmm/messagedialog.h>
+
+#include <gtkmm.h>
 
 #include "util/helpers.h"
 #include "api/evetime.h"
@@ -42,39 +47,28 @@ MainGui::MainGui (void)
   this->actions = Gtk::ActionGroup::create();
   this->uiman = Gtk::UIManager::create();
 
-  this->actions->add(Gtk::Action::create("MenuEveMon",
-      Gtk::Stock::OK, "_EveMon"));
-  this->actions->add(Gtk::Action::create("SetupProfile",
-      Gtk::Stock::ADD, "_Add characters..."),
+  this->actions->add(Gtk::Action::create("MenuEveMon", "_EveMon"));
+  this->actions->add(Gtk::Action::create("SetupProfile", "_Add characters..."),
       sigc::mem_fun(*this, &MainGui::setup_profile));
-  this->actions->add(Gtk::Action::create("Configuration",
-      Gtk::Stock::PREFERENCES, "_Configuration..."),
+  this->actions->add(Gtk::Action::create("Configuration", "_Configuration..."),
       sigc::mem_fun(*this, &MainGui::configuration));
-  this->actions->add(Gtk::Action::create("CheckUpdates",
-      Gtk::Stock::NETWORK, "Check for _updates..."),
+  this->actions->add(Gtk::Action::create("CheckUpdates", "Check for _updates..."),
       sigc::mem_fun(*this, &MainGui::version_checker));
-  this->actions->add(Gtk::Action::create("QuitEveMon", Gtk::Stock::QUIT),
+  this->actions->add(Gtk::Action::create("QuitEveMon", "Quit"),
       sigc::mem_fun(*this, &MainGui::close));
-  this->actions->add(Gtk::Action::create("LaunchEVE",
-      Gtk::Stock::EXECUTE, "_Launch EVE-Online"),
+  this->actions->add(Gtk::Action::create("LaunchEVE", "_Launch EVE-Online"),
       sigc::mem_fun(*this, &MainGui::launch_eve));
 
-  this->actions->add(Gtk::Action::create("MenuCharacter",
-      Gtk::Stock::JUSTIFY_FILL, "_Character"));
-  this->actions->add(Gtk::Action::create("MenuCharPlanning",
-      Gtk::Stock::OK, "_Training planner..."),
+  this->actions->add(Gtk::Action::create("MenuCharacter", "_Character"));
+  this->actions->add(Gtk::Action::create("MenuCharPlanning", "_Training planner..."),
       sigc::mem_fun(*this, &MainGui::create_skillplan));
-  this->actions->add(Gtk::Action::create("MenuCharXMLSource",
-      Gtk::Stock::OK, "View _XML source..."),
+  this->actions->add(Gtk::Action::create("MenuCharXMLSource", "View _XML source..."),
       sigc::mem_fun(*this, &MainGui::view_xml_source));
-  this->actions->add(Gtk::Action::create("MenuCharInfoExport",
-      Gtk::Stock::PRINT, "_Export character..."),
+  this->actions->add(Gtk::Action::create("MenuCharInfoExport", "_Export character..."),
       sigc::mem_fun(*this, &MainGui::export_char_info));
 
-  this->actions->add(Gtk::Action::create("MenuHelp",
-      Gtk::Stock::HELP, "_Help"));
-  this->actions->add(Gtk::Action::create("AboutDialog",
-      Gtk::Stock::ABOUT, "_About..."),
+  this->actions->add(Gtk::Action::create("MenuHelp", "_Help"));
+  this->actions->add(Gtk::Action::create("AboutDialog", "_About..."),
       sigc::mem_fun(*this, &MainGui::about_dialog));
 
   this->uiman->insert_action_group(this->actions);
@@ -134,8 +128,6 @@ MainGui::MainGui (void)
   /* Set the Stock item separately to avoid getting a shortcut key. */
   tmp_item = (Gtk::ImageMenuItem*)this->uiman->get_widget
       ("/MenuBar/MenuCharacter/MenuCharXMLSource");
-  tmp_item->set_image(*Gtk::manage(new Gtk::Image
-      (Gtk::Stock::FIND, Gtk::ICON_SIZE_MENU)));
 
   /* Right-justify the help menu. */
   Gtk::MenuItem* help_menu = (Gtk::MenuItem*)this->uiman->get_widget
@@ -143,7 +135,7 @@ MainGui::MainGui (void)
   help_menu->set_right_justified(true);
 
   /* Create the GUI part of server list. */
-  Gtk::HBox* server_box = Gtk::manage(new Gtk::HBox(false, 5));
+  Gtk::Box* server_box = Gtk::manage(new Gtk::Box);
   server_box->pack_start(*MK_LABEL0, true, true, 0);
 
   for (unsigned int i = 0; i < ServerList::list.size(); ++i)
@@ -157,13 +149,13 @@ MainGui::MainGui (void)
   server_box->pack_start(*MK_LABEL0, true, true, 0);
 
   /* The box with the local and EVE time. */
-  Gtk::HBox* time_hbox = MK_HBOX;
+  Gtk::Box* time_hbox = MK_HBOX(5);
   time_hbox->pack_start(this->evetime_label, false, false, 0);
   time_hbox->pack_end(this->localtime_label, false, false, 0);
 
   /* Build the server monitor with the time box. Ommit the server
    * box if there are no servers to monitor. */
-  Gtk::VBox* server_info_box = Gtk::manage(new Gtk::VBox(false, 2));
+  Gtk::Box* server_info_box = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 2));
   server_info_box->set_border_width(5);
   if (ServerList::list.size() > 0)
   {
@@ -177,13 +169,13 @@ MainGui::MainGui (void)
   server_frame->add(*server_info_box);
 
   /* Pack content area together. */
-  Gtk::VBox* content_vbox = MK_VBOX;
+  Gtk::Box* content_vbox = MK_VBOX(5);
   content_vbox->set_border_width(5);
   content_vbox->pack_start(this->notebook, true, true, 0);
   content_vbox->pack_end(*server_frame, false, false, 0);
 
   /* Pack window contents together. */
-  Gtk::VBox* main_vbox = MK_VBOX0;
+  Gtk::Box* main_vbox = MK_VBOX(0);
   main_vbox->pack_start(*menu_bar, false, false, 0);
   main_vbox->pack_start(this->info_display, false, false, 0);
   main_vbox->pack_start(*content_vbox, true, true, 0);
@@ -268,7 +260,7 @@ MainGui::update_tooltip (void)
     }
   }
 
-  this->tray->set_tooltip(tooltip);
+  this->tray->set_tooltip_text(tooltip);
   return true;
 }
 
@@ -289,13 +281,6 @@ MainGui::init_from_charlist (void)
 void
 MainGui::add_character (CharacterPtr character)
 {
-  /* If tabs are not shown, the welcome page is visible. */
-  if (this->notebook.get_show_tabs() == false)
-  {
-    this->notebook.pages().clear();
-    this->notebook.set_show_tabs(true);
-  }
-
   /* Create the new character page for the notebook. */
   GtkCharPage* page = Gtk::manage(new GtkCharPage(character));
   page->set_parent_window(this);
@@ -335,12 +320,12 @@ MainGui::remove_character (std::string char_id)
 void
 MainGui::check_if_no_pages (void)
 {
-  if (this->notebook.pages().empty())
+  if (this->notebook.get_n_pages() == 0)
   {
-    Gtk::HBox* info_hbox = Gtk::manage(new Gtk::HBox(false, 15));
-    Gtk::Image* info_image = Gtk::manage(new Gtk::Image
-        (Gtk::Stock::DIALOG_INFO, Gtk::ICON_SIZE_DIALOG));
-    info_image->set_alignment(Gtk::ALIGN_RIGHT);
+    Gtk::Box* info_hbox = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 15));
+    Gtk::Image* info_image = MK_IMG0;
+    info_image->set_from_icon_name("dialog-information", Gtk::ICON_SIZE_DIALOG);
+    info_image->set_halign(Gtk::ALIGN_END);
     Gtk::Label* info_label = MK_LABEL
         ("GtkEveMon needs to connect to the EVE API in order to "
         "retrieve information about your character. "
@@ -348,26 +333,24 @@ MainGui::check_if_no_pages (void)
         "You also need to select some characters to be monitored. "
         "Go ahead and add some characters.");
     info_label->set_line_wrap(true);
-    info_label->set_alignment(Gtk::ALIGN_LEFT);
+    info_label->set_halign(Gtk::ALIGN_START);
     info_hbox->pack_start(*info_image, true, true, 0);
     info_hbox->pack_start(*info_label, true, true, 0);
 
-    Gtk::HBox* button_hbox = MK_HBOX;
-    Gtk::Button* add_characters_but = Gtk::manage
-        (new Gtk::Button("Add characters"));
-    add_characters_but->set_image(*Gtk::manage
-        (new Gtk::Image(Gtk::Stock::ADD, Gtk::ICON_SIZE_BUTTON)));
+    Gtk::Box* button_hbox = MK_HBOX(5);
+    Gtk::Button* add_characters_but = MK_BUT("Add characters");
+    add_characters_but->set_image_from_icon_name("list-add", Gtk::ICON_SIZE_BUTTON);
 
     button_hbox->pack_start(*MK_HSEP, true, true, 0);
     button_hbox->pack_start(*add_characters_but, false, false, 0);
     button_hbox->pack_end(*MK_HSEP, true, true, 0);
 
-    Gtk::VBox* upper_vbox = MK_VBOX0;
+    Gtk::Box* upper_vbox = MK_VBOX(0);
     upper_vbox->pack_end(*info_hbox, false, false, 0);
-    Gtk::VBox* bottom_vbox = MK_VBOX0;
+    Gtk::Box* bottom_vbox = MK_VBOX(0);
     bottom_vbox->pack_start(*button_hbox, false, false, 0);
 
-    Gtk::VBox* main_vbox = Gtk::manage(new Gtk::VBox(false, 15));
+    Gtk::Box* main_vbox = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 15));
     main_vbox->set_border_width(5);
     main_vbox->pack_start(*upper_vbox, true, true, 0);
     main_vbox->pack_start(*bottom_vbox, true, true, 0);
@@ -412,7 +395,7 @@ MainGui::update_windowtitle (void)
     return true;
   }
 
-  GtkCharPage* page = (GtkCharPage*)this->notebook.pages()[current].get_child();
+  GtkCharPage* page = (GtkCharPage*)this->notebook.get_nth_page(this->notebook.get_current_page());
   CharacterPtr character = page->get_character();
   Glib::ustring title;
 
@@ -517,7 +500,7 @@ MainGui::on_delete_event (GdkEventAny* /*event*/)
 /* ---------------------------------------------------------------- */
 
 void
-MainGui::on_pages_changed (Gtk::Widget* /*widget*/, guint /*pnum*/)
+MainGui::on_pages_changed (Widget*, guint)
 {
   Gtk::MenuItem* char_menu = (Gtk::MenuItem*)this->uiman->get_widget
       ("/MenuBar/MenuCharacter");
@@ -531,7 +514,7 @@ MainGui::on_pages_changed (Gtk::Widget* /*widget*/, guint /*pnum*/)
 /* ---------------------------------------------------------------- */
 
 void
-MainGui::on_pages_switched (GtkNotebookPage* /*page*/, guint /*pnum*/)
+MainGui::on_pages_switched (Widget*, guint)
 {
   this->update_windowtitle();
 }

--- a/src/gui/maingui.h
+++ b/src/gui/maingui.h
@@ -1,24 +1,19 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef MAIN_GUI_HEADER
 #define MAIN_GUI_HEADER
 
 #include <vector>
-#include <gtkmm/window.h>
-#include <gtkmm/uimanager.h>
-#include <gtkmm/actiongroup.h>
-#include <gtkmm/notebook.h>
-#include <gtkmm/statusicon.h>
+
+#include <gtkmm.h>
 
 #include "util/conf.h"
 #include "bits/character.h"
@@ -58,8 +53,8 @@ class MainGui : public Gtk::Window
     void add_character (CharacterPtr character);
     void remove_character (std::string char_id);
 
-    void on_pages_changed (Gtk::Widget* widget, guint pnum);
-    void on_pages_switched (GtkNotebookPage* page, guint pnum);
+    void on_pages_changed (Widget* page, guint page_num);
+    void on_pages_switched (Widget* page, guint page_num);
     void on_data_files_changed (void);
     void on_data_files_unchanged (void);
     void check_if_no_pages (void);

--- a/src/gui/winbase.h
+++ b/src/gui/winbase.h
@@ -1,19 +1,17 @@
-/*
- * This file is part of GtkEveMon.
- *
- * GtkEveMon is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
- */
+// This file is part of GtkEveMon.
+//
+// GtkEveMon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with GtkEveMon. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef WINBASE_HEADER
 #define WINBASE_HEADER
 
-#include <gtkmm/window.h>
+#include <gtkmm.h>
 
 class WinBase : public Gtk::Window
 {


### PR DESCRIPTION
This pull request contains the port of GtkEveMon to gtkmm version 3. The changeset is huge since there were not only methods obsolete in 3.0 but also those that are still available but already deprecated in 3.x series.

Application successfully compiles against gtkmm3 and starts. It will require extensive testing, however, since I haven't played EVE for a while and hence don't have an API key to test core features.

Fixes #46.

Changelog:
* Application now links against gtkmm v3.
* Individual Glib/GDK/GTK includes replaced by glibmm.h, gdkmm.h, gtkmm.h respectively (as per GNOME recommendations)
* Several methods renamed, otherwise unchanged.
* GUI updater now destroys and recreates the whole files_box instead of removing individual children. (Old method does not work, this method is just plain easier and more reliable)
* Gtk::Stock is deprecated since 3.10 and therefore replaced by theme icons or labels.
* Gtk::HBox and Gtk::VBox are deprecated, containers upgraded to Gtk::Box. Note that Box is on its path to retirement too, it will have to be rewritten as Grid eventually.