### PR TITLE
Fix OS X installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ clean:
 	$(MAKE) -C src clean
 
 install:
-	install -Dm 755 src/gtkevemon $(DESTDIR)$(BINDIR)/gtkevemon
+	mkdir -p $(DESTDIR)$(BINDIR)
+	install -m 755 src/gtkevemon $(DESTDIR)$(BINDIR)/gtkevemon
 	$(MAKE) -C icon
 
 uninstall:

--- a/icon/Makefile
+++ b/icon/Makefile
@@ -4,8 +4,10 @@ PIXMAPDIR ?= $(DATAROOTDIR)/pixmaps
 DESKTOPDIR ?= $(DATAROOTDIR)/applications
 
 install:
-	install -Dm 644 gtkevemon.svg $(DESTDIR)$(PIXMAPDIR)/gtkevemon.svg
-	install -Dm 644 gtkevemon.desktop $(DESTDIR)$(DESKTOPDIR)/gtkevemon.desktop
+	mkdir -p $(DESTDIR)$(PIXMAPDIR)
+	install -m 644 gtkevemon.svg $(DESTDIR)$(PIXMAPDIR)/gtkevemon.svg
+	mkdir -p $(DESTDIR)$(DESKTOPDIR)
+	install -m 644 gtkevemon.desktop $(DESTDIR)$(DESKTOPDIR)/gtkevemon.desktop
 
 uninstall:
 	rm $(DESTDIR)$(PIXMAPDIR)/gtkevemon.svg


### PR DESCRIPTION
`sudo make install` fails on OS X with 

> `install: illegal option -- D`
