### PR TITLE
Add -std=c++11 for g++ versions >= 5

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,6 +53,12 @@ ifeq (${PLATFORM},linux)
   CORES = $(shell grep processor /proc/cpuinfo | wc -l)
   SOURCES = util/pipedexec_posix.cc util/os_unix.cc
   BINARY = gtkevemon
+
+  CXXUSE11 := $(shell expr `g++ -dumpversion | cut -f1 -d.` \>= 5)
+  ifeq "$(CXXUSE11)" "1"
+    GCC_FLAGS += -std=c++11
+  endif
+
 endif
 
 ifeq (${PLATFORM},sunos)

--- a/src/Makefile
+++ b/src/Makefile
@@ -54,7 +54,7 @@ ifeq (${PLATFORM},linux)
   SOURCES = util/pipedexec_posix.cc util/os_unix.cc
   BINARY = gtkevemon
 
-  CXXUSE11 := $(shell expr `g++ -dumpversion | cut -f1 -d.` \>= 5)
+  CXXUSE11 := $(shell expr `g++ -dumpversion | cut -f1,2 -d.` \>= 4.7)
   ifeq "$(CXXUSE11)" "1"
     GCC_FLAGS += -std=c++11
   endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -54,7 +54,14 @@ ifeq (${PLATFORM},linux)
   SOURCES = util/pipedexec_posix.cc util/os_unix.cc
   BINARY = gtkevemon
 
-  CXXUSE11 := $(shell expr `g++ -dumpversion | cut -f1,2 -d.` \>= 4.7)
+  CXXVERSION := $(shell $(CXX) -dumpversion | cut -f1,2 -d.)
+
+  ifeq "$(CXX)" "g++"
+      CXXUSE11 := $(shell expr $(CXXVERSION) \>= 4.7)
+  else ifeq "$(CXX)" "clang"
+      CXXUSE11 := $(shell expr $(CXXVERSION) \>= 3.3)
+  endif
+
   ifeq "$(CXXUSE11)" "1"
     GCC_FLAGS += -std=c++11
   endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -56,9 +56,9 @@ ifeq (${PLATFORM},linux)
 
   CXXVERSION := $(shell $(CXX) -dumpversion | cut -f1,2 -d.)
 
-  ifeq "$(CXX)" "g++"
+  ifneq "$(findstring g++, $(CXX))" ""
       CXXUSE11 := $(shell expr $(CXXVERSION) \>= 4.7)
-  else ifeq "$(CXX)" "clang"
+  else ifneq "$(findstring clang, $(CXX))" ""
       CXXUSE11 := $(shell expr $(CXXVERSION) \>= 3.3)
   endif
 


### PR DESCRIPTION
Some of the headers used complain that they need c++11 support enabled,
which was preventing compilation on my system.